### PR TITLE
setTopText auto splits strings

### DIFF
--- a/titleandsettings/arm9/source/settingsgui.cpp
+++ b/titleandsettings/arm9/source/settingsgui.cpp
@@ -155,6 +155,8 @@ void SettingsGUI::setTopText(const std::string &text)
 		words.push_back(_topTextStr.substr(0, pos));
 		_topTextStr = _topTextStr.substr(pos + 1);
 	}
+	if(_topTextStr.size())
+		words.push_back(_topTextStr);
 	std::string temp;
 	_topText.clear();
 	for(auto word : words)

--- a/titleandsettings/arm9/source/settingsgui.cpp
+++ b/titleandsettings/arm9/source/settingsgui.cpp
@@ -167,14 +167,14 @@ void SettingsGUI::setTopText(const std::string &text)
 	temp.clear();
 	for(auto word : words)
 	{
-		int width = calcLargeFontWidth((temp + word).c_str());
+		int width = calcLargeFontWidth((temp + " " + word).c_str());
 		if(width > 256) {
 			_topText.push_back(temp);
 			temp = word;
 		}
 		else
 		{
-			temp += word;
+			temp += " " + word;
 		}
 	}
 }

--- a/titleandsettings/arm9/source/settingsgui.cpp
+++ b/titleandsettings/arm9/source/settingsgui.cpp
@@ -177,6 +177,8 @@ void SettingsGUI::setTopText(const std::string &text)
 			temp += " " + word;
 		}
 	}
+	if(temp.size())
+	   _topText.push_back(temp);
 }
 
 void SettingsGUI::drawSub()

--- a/titleandsettings/arm9/source/settingsgui.cpp
+++ b/titleandsettings/arm9/source/settingsgui.cpp
@@ -149,22 +149,14 @@ void SettingsGUI::draw()
 void SettingsGUI::setTopText(const std::string &text)
 {
 	std::string _topTextStr(text);
-	_topText.clear();
 	std::vector<std::string> words;
-	std::string temp;
-	for(auto c : _topTextStr)
-	{
-		if(c == ' ')
-		{
-			words.push_back(temp);
-			temp.clear();
-		}
-		else
-			temp += c;
+	std::size_t pos;
+	while((pos = _topTextStr.find(' ')) != std::string::npos) {
+		words.push_back(_topTextStr.substr(0, pos));
+		_topTextStr = _topTextStr.substr(pos + 1);
 	}
-	if(temp.size())
-		words.push_back(temp);
-	temp.clear();
+	std::string temp;
+	_topText.clear();
 	for(auto word : words)
 	{
 		int width = calcLargeFontWidth((temp + " " + word).c_str());

--- a/titleandsettings/arm9/source/settingsgui.cpp
+++ b/titleandsettings/arm9/source/settingsgui.cpp
@@ -146,6 +146,39 @@ void SettingsGUI::draw()
     printSmallCentered(false, 173, ms().getAppName());
 }
 
+void SettingsGUI::setTopText(const std::string &text)
+{
+	std::string _topTextStr(text);
+	_topText.clear();
+	std::vector<std::string> words;
+	std::string temp;
+	for(auto c : _topTextStr)
+	{
+		if(c == ' ')
+		{
+			words.push_back(temp);
+			temp.clear();
+		}
+		else
+			temp += c;
+	}
+	if(temp.size())
+		words.push_back(temp);
+	temp.clear();
+	for(auto word : words)
+	{
+		int width = calcLargeFontWidth((temp + word).c_str());
+		if(width > 256) {
+			_topText.push_back(temp);
+			temp = word;
+		}
+		else
+		{
+			temp += word;
+		}
+	}
+}
+
 void SettingsGUI::drawSub()
 {
     clearText();

--- a/titleandsettings/arm9/source/settingsgui.h
+++ b/titleandsettings/arm9/source/settingsgui.h
@@ -71,18 +71,7 @@ private:
    * Sets the text at the top screen to
    * be printed next call of draw.
    */
-  void setTopText(const std::string &text)
-  {
-    std::string _topTextStr(text);
-    std::size_t pos;
-    _topText.clear();
-    while ((pos = _topTextStr.find('|')) != std::string::npos)
-    {
-      _topText.push_back(_topTextStr.substr(0, pos));
-      _topTextStr = _topTextStr.substr(pos + 1);
-    }
-    _topText.push_back(_topTextStr);
-  }
+  void setTopText(const std::string &text);  
 
   void drawSub();
 


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Now the app should autmatically split the settings in the top screen.

#### Where have you tested it?

I couldn't test it because all my builds failed, and i couldn't properly configure docker on my pc, so i don't even know if it works as intended

*** 
#### Pull Request status
- [ ]  This PR has been tested using latest devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
