### PR TITLE
Acekard theme: Add per game bootstrap choosing

### DIFF
--- a/romsel_aktheme/arm9/source/common/pergamesettings.cpp
+++ b/romsel_aktheme/arm9/source/common/pergamesettings.cpp
@@ -16,6 +16,7 @@ PerGameSettings::PerGameSettings(const std::string &romFileName)
     boostVram = EDefault;
     dsiMode = EDefault;
     directBoot = EFalse;
+    bootstrapFile = EDefault;
     loadSettings();
 }
 
@@ -28,6 +29,7 @@ void PerGameSettings::loadSettings()
 	language = (TLanguage)pergameini.GetInt("GAMESETTINGS", "LANGUAGE", language);
 	boostCpu = (TDefaultBool)pergameini.GetInt("GAMESETTINGS", "BOOST_CPU", boostCpu);
 	boostVram = (TDefaultBool)pergameini.GetInt("GAMESETTINGS", "BOOST_VRAM", boostVram);
+    bootstrapFile = (TDefaultBool)pergameini.GetInt("GAMESETTINGS", "BOOTSTRAP_FILE", bootstrapFile);
 }
 
 void PerGameSettings::saveSettings()
@@ -39,6 +41,7 @@ void PerGameSettings::saveSettings()
 		pergameini.SetInt("GAMESETTINGS", "DSI_MODE", dsiMode);
 		pergameini.SetInt("GAMESETTINGS", "BOOST_CPU", boostCpu);
 		pergameini.SetInt("GAMESETTINGS", "BOOST_VRAM", boostVram);
+        pergameini.SetInt("GAMESETTINGS", "BOOTSTRAP_FILE", bootstrapFile);
 	}
     pergameini.SaveIniFile(_iniPath);
 }

--- a/romsel_aktheme/arm9/source/common/pergamesettings.h
+++ b/romsel_aktheme/arm9/source/common/pergamesettings.h
@@ -41,6 +41,7 @@ class PerGameSettings
     TLanguage language;
     TDefaultBool boostCpu;
     TDefaultBool boostVram;
+    TDefaultBool bootstrapFile;
 
   private:
     std::string _iniPath;

--- a/romsel_aktheme/arm9/source/windows/mainwnd.cpp
+++ b/romsel_aktheme/arm9/source/windows/mainwnd.cpp
@@ -524,7 +524,7 @@ void MainWnd::bootBootstrap(PerGameSettings &gameConfig, DSRomInfo &rominfo)
     config.dsiMode(gameConfig.dsiMode == PerGameSettings::EDefault ? ms().bstrap_dsiMode : (bool)gameConfig.dsiMode)
         .cpuBoost(gameConfig.boostCpu == PerGameSettings::EDefault ? ms().boostCpu : (bool)gameConfig.boostCpu)
         .vramBoost(gameConfig.boostVram == PerGameSettings::EDefault ? ms().boostVram : (bool)gameConfig.boostVram)
-        .nightlyBootstrap(ms().bootstrapFile);
+        .nightlyBootstrap(gameConfig.bootstrapFile == PerGameSettings::EDefault ? ms().bootstrapFile : (bool)gameConfig.bootstrapFile);
 
     // GameConfig is default, global is not default
     if (gameConfig.language == PerGameSettings::ELangDefault && ms().bstrap_language != DSiMenuPlusPlusSettings::ELangDefault)

--- a/romsel_aktheme/arm9/source/windows/rominfownd.cpp
+++ b/romsel_aktheme/arm9/source/windows/rominfownd.cpp
@@ -199,6 +199,13 @@ void RomInfoWnd::pressGameSettings(void)
 
 			settingWnd.addSettingItem(LANG("game settings", "Run in"), _values, settingsIni.dsiMode + 1);
 			_values.clear();
+
+            _values.push_back(LANG("game settings", "Default")); // -1 => 0
+            _values.push_back(LANG("game settings", "Release")); // 0 => 1
+            _values.push_back(LANG("game settings", "Nightly")); // 1 => 2            
+
+            settingWnd.addSettingItem(LANG("game settings", "Bootstrap File"), _values, settingsIni.bootstrapFile + 1);
+            _values.clear();
 		}
 
 		if (isDSiMode()) {
@@ -267,6 +274,8 @@ void RomInfoWnd::pressGameSettings(void)
 				selection++;
 				settingsIni.dsiMode = (PerGameSettings::TDefaultBool)(settingWnd.getItemSelection(0, selection) - 1);
 				selection++;
+                settingsIni.bootstrapFile = (PerGameSettings::TDefaultBool)(settingWnd.getItemSelection(0, selection) - 1);
+                selection++;
 			}
 			if (isDSiMode()) {
 				settingsIni.boostCpu = (PerGameSettings::TDefaultBool)(settingWnd.getItemSelection(0, selection) - 1);


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?
This adds choosing which nds-bootstrap version (release or nightly) you want to use to per game settings on the Acekard theme.

I'm not sure if you actually want to add this, but if you do it's nice to be able to choose nightly for non_blocking_io on just games that work better with it without having to go into settings every time.

If you want I can try add this to the other themes, but the acekard theme is the only one I can compile...

#### Where have you tested it?

On my DSi (J) with the latest Hiya/Unlaunch/TWiLight

*** 
#### Pull Request status
- [x]  This PR has been tested using latest devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
