### PR TITLE
Deleted "_1" and | symbol

### DIFF
--- a/settings/nitrofiles/languages/spanish.ini
+++ b/settings/nitrofiles/languages/spanish.ini
@@ -55,9 +55,9 @@ DESCRIPTION_REPLACEDSIMENU_1_DSISIONX = Iniciar DSiMenu++ al inicio, en lugar de
 
 DESCRIPTION_RESTOREDSIMENU_1 = Volver a mostrar el menu DSi al inicio.
 
-DESCRIPTION_SYSREGION_1 = La region de la SysNAND. La|opcion "Auto" funcionara solo si|la SDNAND esta configurada
+DESCRIPTION_SYSREGION = La region de la SysNAND. La opcion "Auto" funcionara solo si la SDNAND esta configurada
 
-DESCRIPTION_LAUNCHERAPP_1 = Para obtener el nombre del|archivo .app, pulsa POWER,|manten presionado A y|selecciona LAUNCHER
+DESCRIPTION_LAUNCHERAPP = Para obtener el nombre del|archivo .app, pulsa POWER, manten presionado A y selecciona LAUNCHER
 
 DESCRIPTION_DEFAULT_LAUNCHER_1_DSIMENUPP = Lanzar menu DSi o TWLMenu++ al inicio.
 DESCRIPTION_DEFAULT_LAUNCHER_1_SRLOADER = Lanzar menu DSi o SRLoader al inicio.


### PR DESCRIPTION
#### What's changed?

_Removed the "_1" after the "DESCRIPTION" string, and the | symbol._

*** 
#### Pull Request status
- [ ]  This PR has been tested using latest devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
