### PR TITLE
Acekard theme: Hide `saves` folder from being shown

### DIFF
--- a/romsel_aktheme/arm9/source/windows/mainlist.cpp
+++ b/romsel_aktheme/arm9/source/windows/mainlist.cpp
@@ -273,7 +273,7 @@ bool MainList::enterDir(const std::string &dirName)
                     extName = "";
 
                 dbg_printf("%s: %s %s\n", (st.st_mode & S_IFDIR ? " DIR" : "FILE"), lfnBuf, extName.c_str());
-                bool showThis = (st.st_mode & S_IFDIR) ? (strcmp(lfn.c_str(), ".") && strcmp(lfn.c_str(), "..") && strcmp(lfn.c_str(), "_nds") && ms().showDirectories) : extnameFilter(extNames, extName);
+                bool showThis = (st.st_mode & S_IFDIR) ? (strcmp(lfn.c_str(), ".") && strcmp(lfn.c_str(), "..") && strcmp(lfn.c_str(), "_nds") && strcmp(lfn.c_str(), "saves") && ms().showDirectories) : extnameFilter(extNames, extName);
                 showThis = showThis && (_showAllFiles || !(attr & ATTRIB_HID));
 
                 if (showThis)


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Make the Acekard theme hide the `saves` folder too

#### Where have you tested it?

My DSi (JPN), with latest Unlaunch/HiyaCFW/TWiLight

*** 
#### Pull Request status
- [x]  This PR has been tested using latest devkitPro, devkitARM, and EasyGL2D.  
(using RocketRobz libnds fork)

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
