### PR TITLE
Acekard theme: Fix per-game settings windows & list view causing guru error (Fixes #261)

### DIFF
--- a/romsel_aktheme/arm9/source/windows/mainlist.cpp
+++ b/romsel_aktheme/arm9/source/windows/mainlist.cpp
@@ -467,36 +467,39 @@ void MainList::draw()
 
 void MainList::drawIcons()
 {
-    if (VM_LIST != _viewMode)
+    size_t total = _visibleRowCount;
+    if (total > _rows.size() - _firstVisibleRowId)
+        total = _rows.size() - _firstVisibleRowId;
+
+    for (size_t i = 0; i < total; ++i)
     {
-        size_t total = _visibleRowCount;
-        if (total > _rows.size() - _firstVisibleRowId)
-            total = _rows.size() - _firstVisibleRowId;
-
-        for (size_t i = 0; i < total; ++i)
+        if (_firstVisibleRowId + i == _selectedRowId)
         {
-            if (_firstVisibleRowId + i == _selectedRowId)
+            if (_activeIcon.visible())
             {
-                if (_activeIcon.visible())
-                {
-                    continue;
-                }
+                continue;
             }
-            s32 itemX = _position.x + 1;
-            s32 itemY = _position.y + i * _rowHeight + ((_rowHeight - 32) >> 1) - 1;
-            if (_romInfoList[_firstVisibleRowId + i].isBannerAnimated() && ms().animateDsiIcons)
-            {
-                int seqIdx = seq().allocate_sequence(
-                    _romInfoList[_firstVisibleRowId + i].saveInfo().gameCode,
-                    _romInfoList[_firstVisibleRowId + i].animatedIcon().sequence);
+        }
+        s32 itemX = _position.x + 1;
+        s32 itemY = _position.y + i * _rowHeight + ((_rowHeight - 32) >> 1) - 1;
+        if (_romInfoList[_firstVisibleRowId + i].isBannerAnimated() && ms().animateDsiIcons)
+        {
+            int seqIdx = seq().allocate_sequence(
+                _romInfoList[_firstVisibleRowId + i].saveInfo().gameCode,
+                _romInfoList[_firstVisibleRowId + i].animatedIcon().sequence);
 
-                int bmpIdx = seq()._dsiIconSequence[seqIdx]._bitmapIndex;
-                int palIdx = seq()._dsiIconSequence[seqIdx]._paletteIndex;
-                bool flipH = seq()._dsiIconSequence[seqIdx]._flipH;
-                bool flipV = seq()._dsiIconSequence[seqIdx]._flipV;
+            int bmpIdx = seq()._dsiIconSequence[seqIdx]._bitmapIndex;
+            int palIdx = seq()._dsiIconSequence[seqIdx]._paletteIndex;
+            bool flipH = seq()._dsiIconSequence[seqIdx]._flipH;
+            bool flipV = seq()._dsiIconSequence[seqIdx]._flipV;
+            if (VM_LIST != _viewMode)
+            {
                 _romInfoList[_firstVisibleRowId + i].drawDSiAnimatedRomIcon(itemX, itemY, bmpIdx, palIdx, flipH, flipV, _engine);
             }
-            else
+        }
+        else
+        {
+            if (VM_LIST != _viewMode)
             {
                 _romInfoList[_firstVisibleRowId + i].drawDSRomIcon(itemX, itemY, _engine);
             }

--- a/romsel_aktheme/arm9/source/windows/rominfownd.cpp
+++ b/romsel_aktheme/arm9/source/windows/rominfownd.cpp
@@ -279,31 +279,32 @@ void RomInfoWnd::pressGameSettings(void)
 		int selection = 0;
         if (!_romInfo.isHomebrew())
         {
-			if (!ms().secondaryDevice) {
-				settingsIni.language = (PerGameSettings::TLanguage)(settingWnd.getItemSelection(0, selection) - 2);
-				selection++;
-				settingsIni.dsiMode = (PerGameSettings::TDefaultBool)(settingWnd.getItemSelection(0, selection) - 1);
-				selection++;
-                settingsIni.bootstrapFile = (PerGameSettings::TDefaultBool)(settingWnd.getItemSelection(0, selection) - 1);
+            if (!ms().secondaryDevice) {
+                settingsIni.language = (PerGameSettings::TLanguage)(settingWnd.getItemSelection(0, selection) - 2);
                 selection++;
-			}
-			if (isDSiMode()) {
-				settingsIni.boostCpu = (PerGameSettings::TDefaultBool)(settingWnd.getItemSelection(0, selection) - 1);
-				selection++;
-				settingsIni.boostVram = (PerGameSettings::TDefaultBool)(settingWnd.getItemSelection(0, selection) - 1);
-			}
+                settingsIni.dsiMode = (PerGameSettings::TDefaultBool)(settingWnd.getItemSelection(0, selection) - 1);
+                selection++;
+            }
+            if (isDSiMode()) {
+                settingsIni.boostCpu = (PerGameSettings::TDefaultBool)(settingWnd.getItemSelection(0, selection) - 1);
+                selection++;
+                settingsIni.boostVram = (PerGameSettings::TDefaultBool)(settingWnd.getItemSelection(0, selection) - 1);
+                selection++;
+            }
+            settingsIni.bootstrapFile = (PerGameSettings::TDefaultBool)(settingWnd.getItemSelection(0, selection) - 1);
+                selection++;
         }
         else
         {
             settingsIni.directBoot = (PerGameSettings::TDefaultBool)(settingWnd.getItemSelection(0, selection) - 1);
-			if (isDSiMode()) {
-				selection++;
-				settingsIni.dsiMode = (PerGameSettings::TDefaultBool)(settingWnd.getItemSelection(0, selection) - 1);
-				selection++;
-				settingsIni.boostCpu = (PerGameSettings::TDefaultBool)(settingWnd.getItemSelection(0, selection) - 1);
-				selection++;
-				settingsIni.boostVram = (PerGameSettings::TDefaultBool)(settingWnd.getItemSelection(0, selection) - 1);
-			}
+            if (isDSiMode()) {
+                selection++;
+                settingsIni.dsiMode = (PerGameSettings::TDefaultBool)(settingWnd.getItemSelection(0, selection) - 1);
+                selection++;
+                settingsIni.boostCpu = (PerGameSettings::TDefaultBool)(settingWnd.getItemSelection(0, selection) - 1);
+                selection++;
+                settingsIni.boostVram = (PerGameSettings::TDefaultBool)(settingWnd.getItemSelection(0, selection) - 1);
+            }
        }
         settingsIni.saveSettings();
     }


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Saving to the ini file was out of order, so everything saved to the wrong values. This fixes that.

EDIT (2<sup>nd</sup> commit): Now this also fixes the compact list view causing a guru error by loading in the rom icons, but not drawing them on screen. (Fixes #261)

#### Where have you tested it?

DSi (J) latest TWiLight / HiyaCFW / Unlaunch

*** 
#### Pull Request status
- [x]  This PR has been tested using latest devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
