### PR TITLE
Acekard theme: Fix not saving hb rom's bootstrap file

### DIFF
--- a/romsel_aktheme/arm9/source/windows/rominfownd.cpp
+++ b/romsel_aktheme/arm9/source/windows/rominfownd.cpp
@@ -297,6 +297,7 @@ void RomInfoWnd::pressGameSettings(void)
                 selection++;
                 settingsIni.boostVram = (PerGameSettings::TDefaultBool)(settingWnd.getItemSelection(0, selection) - 1);
             }
+            selection++;
             settingsIni.bootstrapFile = (PerGameSettings::TDefaultBool)(settingWnd.getItemSelection(0, selection) - 1);
         }
         else
@@ -312,6 +313,8 @@ void RomInfoWnd::pressGameSettings(void)
                 selection++;
                 settingsIni.boostVram = (PerGameSettings::TDefaultBool)(settingWnd.getItemSelection(0, selection) - 1);
             }
+            selection++;
+            settingsIni.bootstrapFile = (PerGameSettings::TDefaultBool)(settingWnd.getItemSelection(0, selection) - 1);
 		}
         settingsIni.saveSettings();
     }


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

The Acekard theme wasn't saving the `Bootstrap File` option in per-game settings, now it does

#### Where have you tested it?

DSi (J) with latest HiyaCFW / TWiLight / Unlaunch

*** 
#### Pull Request status
- [x]  This PR has been tested using latest devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
