### PR TITLE
Acekard theme: Reimplement the cheat UI and add the ability to show the day of the week

### DIFF
--- a/romsel_aktheme/arm9/source/common/bootstrapconfig.h
+++ b/romsel_aktheme/arm9/source/common/bootstrapconfig.h
@@ -45,12 +45,14 @@ class BootstrapConfig
 
         int launch();
 
+        std::string _cheatData;
 
 
     private:
 
         void createSaveFileIfNotExists();
         void createTmpFileIfNotExists();
+        void loadCheats();
 
         const std::string _fileName;
         const std::string _fullPath;

--- a/romsel_aktheme/arm9/source/systemfilenames.h
+++ b/romsel_aktheme/arm9/source/systemfilenames.h
@@ -52,6 +52,7 @@
 #define SFN_CLOCK_COLON             SFN_UI_DIRECTORY"/calendar/clock_colon.bmp"
 #define SFN_DAY_NUMBERS             SFN_UI_DIRECTORY"/calendar/day_numbers.bmp"
 #define SFN_YEAR_NUMBERS            SFN_UI_DIRECTORY"/calendar/year_numbers.bmp"
+#define SFN_WEEKDAY_TEXT            SFN_UI_DIRECTORY"/calendar/weekday_text.bmp"
 #define SFN_CARD_ICON_BLUE          SFN_UI_DIRECTORY"/card_icon_blue.bmp"
 #define SFN_PROGRESS_WND_BG         SFN_UI_DIRECTORY"/progress_wnd.bmp"
 #define SFN_PROGRESS_BAR_BG         SFN_UI_DIRECTORY"/progress_bar.bmp"
@@ -73,6 +74,7 @@
 #define SFN_CLOCK_COLON_2           SFN_UI_DIRECTORY"/calendar/clock_colon_2.bmp"
 #define SFN_DAY_NUMBERS_2           SFN_UI_DIRECTORY"/calendar/day_numbers_2.bmp"
 #define SFN_YEAR_NUMBERS_2          SFN_UI_DIRECTORY"/calendar/year_numbers_2.bmp"
+#define SFN_WEEKDAY_TEXT_2          SFN_UI_DIRECTORY"/calendar/weekday_text_2.bmp"
 
 #define SFN_LIST_BAR_BG             SFN_UI_DIRECTORY"/selection_bar_bg.bmp"
 

--- a/romsel_aktheme/arm9/source/windows/calendar.cpp
+++ b/romsel_aktheme/arm9/source/windows/calendar.cpp
@@ -52,6 +52,9 @@ Window &Calendar::loadAppearance(const std::string &aFileName)
     // load year number
     _yearNumbers = createBMP15FromFile(SFN_YEAR_NUMBERS);
 
+    // load weekday text
+    _weekdayText = createBMP15FromFile(SFN_WEEKDAY_TEXT);
+
     CIniFile ini(aFileName);
     _dayPosition.x = ini.GetInt("calendar day", "x", 134);
     _dayPosition.y = ini.GetInt("calendar day", "y", 34);
@@ -71,6 +74,10 @@ Window &Calendar::loadAppearance(const std::string &aFileName)
     _yearPosition.x = ini.GetInt("calendar year", "x", 52);
     _yearPosition.y = ini.GetInt("calendar year", "y", 28);
     _showYear = ini.GetInt("calendar year", "show", _showYear);
+
+    _weekdayPosition.x = ini.GetInt("calendar weekday", "x", 52);
+    _weekdayPosition.y = ini.GetInt("calendar weekday", "y", 28);
+    _showWeekday = ini.GetInt("calendar weekday", "show", _showWeekday);
 
     return *this;
 }
@@ -104,6 +111,20 @@ void Calendar::drawDayNumber(u8 day)
         gdi().maskBlt(_dayNumbers.buffer() + firstNumber * pitch * h / 2, x, y, w, h, selectedEngine());
         gdi().maskBlt(_dayNumbers.buffer() + secondNumber * pitch * h / 2, x + w, y, w, h, selectedEngine());
     }
+}
+
+void Calendar::drawWeekday(const akui::Point &position, u32 value)
+{
+    if (!_weekdayText.valid())
+        return;
+
+    u8 w = _weekdayText.width();
+    u8 h = _weekdayText.height() / 7;
+    u8 pitch = _weekdayText.pitch() >> 1;
+    u8 x = position.x;
+    u8 y = position.y;
+
+    gdi().maskBlt(_weekdayText.buffer() + value * pitch * h / 2, x, y, w, h, selectedEngine());
 }
 
 u8 Calendar::weekDayOfFirstDay()
@@ -161,5 +182,9 @@ void Calendar::draw()
     if (_showYear)
     {
         drawText(_yearPosition, datetime().year(), 1000);
+    }
+    if (_showWeekday)
+    {
+        drawWeekday(_weekdayPosition, datetime().weekday());
     }
 }

--- a/romsel_aktheme/arm9/source/windows/calendar.h
+++ b/romsel_aktheme/arm9/source/windows/calendar.h
@@ -51,20 +51,24 @@ protected:
     void drawDayNumber( u8 day );
     void drawText( const akui::Point& position, u32 value, u32 factor );
     void drawNumber( const akui::Point& position, u32 index, u32 value );
+    void drawWeekday( const akui::Point& position, u32 value );
 
     akui::Point _dayPosition;
     akui::Size _daySize;
     akui::Point _dayxPosition;
     akui::Point _monthPosition;
     akui::Point _yearPosition;
+    akui::Point _weekdayPosition;
     COLOR _dayHighlightColor;
     BMP15 _dayNumbers;       // index 10 means colon
     BMP15 _yearNumbers;
+    BMP15 _weekdayText;
 
     bool _showYear;
     bool _showMonth;
     bool _showDayX;
     bool _showDay;
+    bool _showWeekday;
 
     bool _colonShow;
 };

--- a/romsel_aktheme/arm9/source/windows/calendar_2.cpp
+++ b/romsel_aktheme/arm9/source/windows/calendar_2.cpp
@@ -52,6 +52,9 @@ Window &Calendar_2::loadAppearance(const std::string &aFileName)
     // load year number
     _yearNumbers = createBMP15FromFile(SFN_YEAR_NUMBERS_2);
 
+    // load weekday text
+    _weekdayText = createBMP15FromFile(SFN_WEEKDAY_TEXT_2);
+
     CIniFile ini(aFileName);
     _dayPosition.x = ini.GetInt("calendar day 2", "x", 134);
     _dayPosition.y = ini.GetInt("calendar day 2", "y", 34);
@@ -71,6 +74,10 @@ Window &Calendar_2::loadAppearance(const std::string &aFileName)
     _yearPosition.x = ini.GetInt("calendar year 2", "x", 52);
     _yearPosition.y = ini.GetInt("calendar year 2", "y", 28);
     _showYear_2 = ini.GetInt("calendar year 2", "show", _showYear_2);
+
+    _weekdayPosition.x = ini.GetInt("calendar weekday 2", "x", 52);
+    _weekdayPosition.y = ini.GetInt("calendar weekday 2", "y", 28);
+    _showWeekday_2 = ini.GetInt("calendar weekday 2", "show", _showWeekday_2);
 
     return *this;
 }
@@ -105,6 +112,21 @@ void Calendar_2::drawDayNumber(u8 day)
         gdi().maskBlt(_dayNumbers.buffer() + secondNumber * pitch * h / 2, x + w, y, w, h, selectedEngine());
     }
 }
+
+void Calendar_2::drawWeekday(const akui::Point &position, u32 value)
+{
+    if (!_weekdayText.valid())
+        return;
+
+    u8 w = _weekdayText.width();
+    u8 h = _weekdayText.height() / 7;
+    u8 pitch = _weekdayText.pitch() >> 1;
+    u8 x = position.x;
+    u8 y = position.y;
+
+    gdi().maskBlt(_weekdayText.buffer() + value * pitch * h / 2, x, y, w, h, selectedEngine());
+}
+
 
 u8 Calendar_2::weekDayOfFirstDay()
 {
@@ -161,5 +183,9 @@ void Calendar_2::draw()
     if (_showYear_2)
     {
         drawText(_yearPosition, datetime().year(), 1000);
+    }
+    if (_showWeekday_2)
+    {
+        drawWeekday(_weekdayPosition, datetime().weekday());
     }
 }

--- a/romsel_aktheme/arm9/source/windows/calendar_2.h
+++ b/romsel_aktheme/arm9/source/windows/calendar_2.h
@@ -51,20 +51,24 @@ protected:
     void drawDayNumber( u8 day );
     void drawText( const akui::Point& position, u32 value, u32 factor );
     void drawNumber( const akui::Point& position, u32 index, u32 value );
+    void drawWeekday( const akui::Point& position, u32 value );
 
     akui::Point _dayPosition;
     akui::Size _daySize;
     akui::Point _dayxPosition;
     akui::Point _monthPosition;
     akui::Point _yearPosition;
+    akui::Point _weekdayPosition;
     COLOR _dayHighlightColor;
     BMP15 _dayNumbers;       // index 10 means colon
     BMP15 _yearNumbers;
+    BMP15 _weekdayText;
 
     bool _showYear_2;
     bool _showMonth_2;
     bool _showDayX_2;
     bool _showDay_2;
+    bool _showWeekday_2;
 
     bool _colonShow_2;
 };

--- a/romsel_aktheme/arm9/source/windows/cheatwnd.cpp
+++ b/romsel_aktheme/arm9/source/windows/cheatwnd.cpp
@@ -514,9 +514,9 @@ std::string CheatWnd::getCheats()
   {
     if(_data[i]._flags&cParsedItem::ESelected)
     {
-      cheats += _data[i]._cheat.substr(0, _data[i]._cheat.size()-1);
+      cheats += _data[i]._cheat.substr(0, _data[i]._cheat.size());
     }
   }
-  std::replace( cheats.begin(), cheats.end(), '\n', ' '); // replace all '\n' to ' '
+  std::replace( cheats.begin(), cheats.end(), '\n', ' ');
   return cheats;
 }

--- a/romsel_aktheme/arm9/source/windows/cheatwnd.cpp
+++ b/romsel_aktheme/arm9/source/windows/cheatwnd.cpp
@@ -1,0 +1,522 @@
+/*
+    cheatwnd.cpp
+    Portions copyright (C) 2008 Normmatt, www.normmatt.com, Smiths (www.emuholic.com)
+    Portions copyright (C) 2008 bliss (bliss@hanirc.org)
+    Copyright (C) 2009 yellow wood goblin
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "cheatwnd.h"
+#include "ui/uisettings.h"
+#include "ui/windowmanager.h"
+#include "language.h"
+#include "ui/msgbox.h"
+#include "gamecode.h"
+#include <sys/stat.h>
+#include <algorithm>
+// #include <elm.h>
+
+using namespace akui;
+
+#define CRCPOLY 0xedb88320
+static u32 crc32(const u8* p,size_t len)
+{
+  u32 crc=-1;
+  while(len--)
+  {
+    crc^=*p++;
+    for(int ii=0;ii<8;++ii) crc=(crc>>1)^((crc&1)?CRCPOLY:0);
+  }
+  return crc;
+}
+
+
+CheatWnd::CheatWnd(s32 x,s32 y,u32 w,u32 h,Window* parent,const std::string& text):
+Form(x,y,w,h,parent,text),
+_buttonDeselect(0,0,46,18,this,"\x05 Deselect"),
+_buttonInfo(0,0,46,18,this,"\x04 Info"),
+_buttonGenerate(0,0,46,18,this,"\x03 OK"),
+_buttonCancel(0,0,46,18,this,"\x02 Cancel"),
+_List(0,0,w-8,h-44,this,"cheat tree", ms().ak_scrollSpeed)
+{
+  s16 buttonY=size().y-_buttonCancel.size().y-4;
+
+  _buttonCancel.setStyle(Button::press);
+  _buttonCancel.setText("\x02 "+LANG("setting window","cancel"));
+  _buttonCancel.setTextColor(uis().buttonTextColor);
+  _buttonCancel.loadAppearance(SFN_BUTTON3);
+  _buttonCancel.clicked.connect(this,&CheatWnd::onCancel);
+  addChildWindow(&_buttonCancel);
+
+  _buttonGenerate.setStyle(Button::press);
+  _buttonGenerate.setText( "\x03 " + LANG( "setting window", "ok" ) );
+  _buttonGenerate.setTextColor(uis().buttonTextColor);
+  _buttonGenerate.loadAppearance(SFN_BUTTON2);
+  _buttonGenerate.clicked.connect(this,&CheatWnd::onGenerate);
+  addChildWindow(&_buttonGenerate);
+
+  _buttonInfo.setStyle(Button::press);
+  _buttonInfo.setText( "\x04 " + LANG( "cheats", "info" ) );
+  _buttonInfo.setTextColor(uis().buttonTextColor);
+  _buttonInfo.loadAppearance(SFN_BUTTON3);
+  _buttonInfo.clicked.connect(this,&CheatWnd::onInfo);
+  addChildWindow(&_buttonInfo);
+
+  _buttonDeselect.setStyle(Button::press);
+  _buttonDeselect.setText( "\x05 " + LANG( "cheats", "deselect" ) );
+  _buttonDeselect.setTextColor(uis().buttonTextColor);
+  _buttonDeselect.loadAppearance(SFN_BUTTON4);
+  _buttonDeselect.clicked.connect(this,&CheatWnd::onDeselectAll);
+  addChildWindow(&_buttonDeselect);
+
+  s16 nextButtonX=size().x;
+  s16 buttonPitch=_buttonCancel.size().x+4;
+  nextButtonX-=buttonPitch;
+  _buttonCancel.setRelativePosition(Point(nextButtonX,buttonY));
+
+  buttonPitch=_buttonGenerate.size().x+4;
+  nextButtonX-=buttonPitch;
+  _buttonGenerate.setRelativePosition(Point(nextButtonX,buttonY));
+
+  buttonPitch=_buttonInfo.size().x+4;
+  nextButtonX-=buttonPitch;
+  _buttonInfo.setRelativePosition(Point(nextButtonX,buttonY));
+
+  buttonPitch=_buttonDeselect.size().x+4;
+  nextButtonX-=buttonPitch;
+  _buttonDeselect.setRelativePosition(Point(nextButtonX,buttonY));
+
+  _List.setRelativePosition(Point(4, 20));
+
+  //CIniFile ini(SFN_UI_SETTINGS);
+  //_List.setColors(ini.GetInt("main list","textColor",RGB15(7,7,7)),ini.GetInt("main list","textColorHilight",RGB15(31,0,31)),ini.GetInt("main list","selectionBarColor1",RGB15(16,20,24)),ini.GetInt("main list","selectionBarColor2",RGB15(20,25,0)));
+
+  _List.insertColumn(0,"icon",EIconWidth);
+  _List.insertColumn(1,"showName",_List.size().x+2-EIconWidth);
+  _List.arangeColumnsSize();
+  _List.setRowHeight(ERowHeight);
+  _List.selectedRowClicked.connect(this,&CheatWnd::onItemClicked);
+  _List.ownerDraw.connect(this,&CheatWnd::onDraw);
+  addChildWindow(&_List);
+
+  loadAppearance("");
+  arrangeChildren();
+}
+
+CheatWnd::~CheatWnd()
+{}
+
+void CheatWnd::draw()
+{
+  _renderDesc.draw(windowRectangle(),_engine);
+  Form::draw();
+}
+
+bool CheatWnd::process(const akui::Message& msg)
+{
+  bool ret=false;
+  ret=Form::process(msg);
+  if(!ret)
+  {
+    if(msg.id()>Message::keyMessageStart&&msg.id()<Message::keyMessageEnd)
+    {
+      ret=processKeyMessage((KeyMessage&)msg);
+    }
+  }
+  return ret;
+}
+
+bool CheatWnd::processKeyMessage(const KeyMessage& msg)
+{
+  bool ret=false;
+  if(msg.id()==Message::keyDown)
+  {
+    switch(msg.keyCode())
+    {
+      case KeyMessage::UI_KEY_DOWN:
+        _List.selectNext();
+        ret=true;
+        break;
+      case KeyMessage::UI_KEY_UP:
+        _List.selectPrev();
+        ret=true;
+        break;
+      case KeyMessage::UI_KEY_LEFT:
+        {
+          size_t ii=_List.selectedRowId();
+          while(--ii>0)
+          {
+            if(_data[_indexes[ii]]._flags&cParsedItem::EFolder) break;
+          }
+          _List.selectRow(ii);
+        }
+        ret=true;
+        break;
+      case KeyMessage::UI_KEY_RIGHT:
+        {
+          size_t ii=_List.selectedRowId(),top=_List.getRowCount();
+          while(++ii<top)
+          {
+            if(_data[_indexes[ii]]._flags&cParsedItem::EFolder) break;
+          }
+          _List.selectRow(ii);
+        }
+        ret=true;
+        break;
+      case KeyMessage::UI_KEY_A:
+        onSelect();
+        ret=true;
+        break;
+      case KeyMessage::UI_KEY_B:
+        onCancel();
+        ret=true;
+        break;
+      case KeyMessage::UI_KEY_X:
+        onGenerate();
+        ret=true;
+        break;
+      case KeyMessage::UI_KEY_Y:
+        onInfo();
+        ret=true;
+        break;
+      case KeyMessage::UI_KEY_L:
+        onDeselectAll();
+        ret=true;
+        break;
+      default:
+        break;
+    }
+  }
+  return ret;
+}
+
+Window& CheatWnd::loadAppearance(const std::string& aFileName )
+{
+  _renderDesc.loadData(SFN_FORM_TITLE_L,SFN_FORM_TITLE_R,SFN_FORM_TITLE_M);
+  _renderDesc.setTitleText(_text);
+  return *this;
+}
+
+void CheatWnd::onItemClicked(u32 index)
+{
+  (void)index;
+  onSelect();
+}
+
+void CheatWnd::onSelect(void)
+{
+  size_t index=_indexes[_List.selectedRowId()];
+  if(_data[index]._flags&cParsedItem::EFolder)
+  {
+    _data[index]._flags^=cParsedItem::EOpen;
+    u32 first=_List.firstVisibleRowId(),row=_List.selectedRowId();
+    generateList();
+    _List.setFirstVisibleIdAndSelectRow(first,row);
+  }
+  else
+  {
+    bool deselect=(_data[index]._flags&(cParsedItem::EOne|cParsedItem::ESelected))==(cParsedItem::EOne|cParsedItem::ESelected);
+    if(_data[index]._flags&cParsedItem::EOne) deselectFolder(index);
+    if(!deselect) _data[index]._flags^=cParsedItem::ESelected;
+  }
+}
+
+void CheatWnd::onDeselectAll(void)
+{
+  std::vector<cParsedItem>::iterator itr=_data.begin();
+  while(itr!=_data.end())
+  {
+    (*itr)._flags&=~cParsedItem::ESelected;
+    ++itr;
+  }
+}
+
+void CheatWnd::onInfo(void)
+{
+  size_t index=_indexes[_List.selectedRowId()];
+  std::string body(_data[index]._title);
+  body+="\n\n";
+  body+=_data[index]._comment;
+  messageBox(this,LANG("cheats","title"),body,MB_OK);
+}
+
+void CheatWnd::onCancel(void)
+{
+  Form::onCancel();
+}
+
+static void updateDB(u8 value,u32 offset,FILE* db)
+{
+  u8 oldvalue;
+  if(!db) return;
+  if(!offset) return;
+  if(fseek(db,offset,SEEK_SET)) return;
+  if(fread(&oldvalue,sizeof(oldvalue),1,db)!=1) return;
+  if(oldvalue!=value)
+  {
+    if(fseek(db,offset,SEEK_SET)) return;
+    fwrite(&value,sizeof(value),1,db);
+  }
+}
+
+void CheatWnd::onGenerate(void)
+{
+  FILE* db=fopen(SFN_CHEATS,"r+b");
+  if(db)
+  {
+    std::vector<cParsedItem>::iterator itr=_data.begin();
+    while(itr!=_data.end())
+    {
+      updateDB(((*itr)._flags&cParsedItem::ESelected)?1:0,(*itr)._offset,db);
+      ++itr;
+    }
+    fclose(db);
+  }
+  Form::onOK();
+}
+
+void CheatWnd::drawMark(const ListView::OwnerDraw& od,u16 width)
+{
+  u16 color=gdi().getPenColor(od._engine);
+  u16 size=od._size.y-ESelectTop*2;
+  gdi().fillRect(color,color,od._position.x+((width-size)>>1)-1,od._position.y+ESelectTop,size,size,od._engine);
+}
+
+void CheatWnd::onDraw(const ListView::OwnerDraw& od)
+{
+  size_t index=_indexes[od._row];
+  u32 flags=_data[index]._flags;
+  if(od._col==EIconColumn)
+  {
+    if(flags&cParsedItem::EFolder)
+    {
+      u16 size=od._size.y-EFolderTop*2;
+      s16 x1=od._position.x+((od._size.x-size)>>1)-1,x2=x1+(size>>1),y1=od._position.y+EFolderTop,y2=y1+(size>>1);
+      gdi().frameRect(x1,y1,size,size,od._engine);
+      gdi().drawLine(x1,y2,x1+size,y2,od._engine);
+      if(!(flags&cParsedItem::EOpen)) gdi().drawLine(x2,y1,x2,y1+size,od._engine);
+    }
+    else if(!(flags&cParsedItem::EInFolder))
+    {
+      if(flags&cParsedItem::ESelected) drawMark(od,od._size.x);
+    }
+  }
+  else if(od._col==ETextColumn)
+  {
+    if(flags&cParsedItem::EInFolder)
+    {
+      if(flags&cParsedItem::ESelected) drawMark(od,EFolderWidth);
+    }
+    s16 x=od._position.x; u16 w=od._size.x;
+    if(flags&cParsedItem::EInFolder)
+    {
+      x+=EFolderWidth;
+      w-=EFolderWidth;
+    }
+    gdi().textOutRect(x,od._textY,w,od._textHeight,od._text,od._engine);
+  }
+}
+
+bool CheatWnd::parse(const std::string& aFileName)
+{
+  bool res=false;
+  _fileName=aFileName;
+  u32 romcrc32,gamecode;
+  if(romData(_fileName,gamecode,romcrc32))
+  {
+    FILE* dat=fopen(SFN_CHEATS,"rb");
+    if(dat)
+    {
+      res=parseInternal(dat,gamecode,romcrc32);
+      fclose(dat);
+    }
+  }
+  return res;
+}
+
+bool CheatWnd::romData(const std::string& aFileName,u32& aGameCode,u32& aCrc32)
+{
+  bool res=false;
+  FILE* rom=fopen(aFileName.c_str(),"rb");
+  if(rom)
+  {
+    u8 header[512];
+    if(1==fread(header,sizeof(header),1,rom))
+    {
+      aCrc32=crc32(header,sizeof(header));
+      aGameCode=gamecode((const char*)(header+12));
+      res=true;
+    }
+    fclose(rom);
+  }
+  return res;
+}
+
+bool CheatWnd::searchCheatData(FILE* aDat,u32 gamecode,u32 crc32,long& aPos,size_t& aSize)
+{
+  aPos=0;
+  aSize=0;
+  const char* KHeader="R4 CheatCode";
+  char header[12];
+  fread(header,12,1,aDat);
+  if(strncmp(KHeader,header,12)) return false;
+
+  sDatIndex idx,nidx;
+
+  fseek(aDat,0,SEEK_END);
+  long fileSize=ftell(aDat);
+
+  fseek(aDat,0x100,SEEK_SET);
+  fread(&nidx,sizeof(nidx),1,aDat);
+
+  bool done=false;
+
+  while(!done)
+  {
+    memcpy(&idx,&nidx,sizeof(idx));
+    fread(&nidx,sizeof(nidx),1,aDat);
+    if(gamecode==idx._gameCode&&crc32==idx._crc32)
+    {
+      aSize=((nidx._offset)?nidx._offset:fileSize)-idx._offset;
+      aPos=idx._offset;
+      done=true;
+    }
+    if(!nidx._offset) done=true;
+  }
+  return (aPos&&aSize);
+}
+
+bool CheatWnd::parseInternal(FILE* aDat,u32 gamecode,u32 crc32)
+{
+  dbg_printf("%x, %x\n",gamecode,crc32);
+
+  _data.clear();
+
+  long dataPos; size_t dataSize;
+  if(!searchCheatData(aDat,gamecode,crc32,dataPos,dataSize)) return false;
+  fseek(aDat,dataPos,SEEK_SET);
+
+  dbg_printf("record found: %d\n",dataSize);
+
+  char* buffer=(char*)malloc(dataSize);
+  if(!buffer) return false;
+  fread(buffer,dataSize,1,aDat);
+  char* gameTitle=buffer;
+
+  u32* ccode=(u32*)(((u32)gameTitle+strlen(gameTitle)+4)&~3);
+  u32 cheatCount=*ccode;
+  cheatCount&=0x0fffffff;
+  ccode+=9;
+
+  u32 cc=0;
+  while(cc<cheatCount)
+  {
+    u32 folderCount=1;
+    char* folderName=NULL;
+    char* folderNote=NULL;
+    u32 flagItem=0;
+    if((*ccode>>28)&1)
+    {
+      flagItem|=cParsedItem::EInFolder;
+      if((*ccode>>24)==0x11) flagItem|=cParsedItem::EOne;
+      folderCount=*ccode&0x00ffffff;
+      folderName=(char*)((u32)ccode+4);
+      folderNote=(char*)((u32)folderName+strlen(folderName)+1);
+      _data.push_back(cParsedItem(folderName,folderNote,cParsedItem::EFolder));
+      cc++;
+      ccode=(u32*)(((u32)folderName+strlen(folderName)+1+strlen(folderNote)+1+3)&~3);
+    }
+
+    u32 selectValue=cParsedItem::ESelected;
+    for(size_t ii=0;ii<folderCount;++ii)
+    {
+      char* cheatName=(char*)((u32)ccode+4);
+      char* cheatNote=(char*)((u32)cheatName+strlen(cheatName)+1);
+      u32* cheatData=(u32*)(((u32)cheatNote+strlen(cheatNote)+1+3)&~3);
+      u32 cheatDataLen=*cheatData++;
+
+      if(cheatDataLen)
+      {
+        _data.push_back(cParsedItem(cheatName,cheatNote,flagItem|((*ccode&0xff000000)?selectValue:0),dataPos+(((char*)ccode+3)-buffer)));
+        if((*ccode&0xff000000)&&(flagItem&cParsedItem::EOne)) selectValue=0;
+        for(size_t jj=0;jj<cheatDataLen;++jj)
+        {
+          _data.back()._cheat+=formatString("%08X",*(cheatData+jj));
+          _data.back()._cheat+=((jj+1)%2)?" ":"\n";
+        }
+        if(cheatDataLen%2) _data.back()._cheat+="\n";
+      }
+      cc++;
+      ccode=(u32*)((u32)ccode+(((*ccode&0x00ffffff)+1)*4));
+    }
+  }
+  free(buffer);
+  generateList();
+  return true;
+}
+
+void CheatWnd::generateList(void)
+{
+  _indexes.clear();
+  _List.removeAllRows();
+
+  std::vector<cParsedItem>::iterator itr=_data.begin();
+  while(itr!=_data.end())
+  {
+    std::vector<std::string> row;
+    row.push_back("");
+    row.push_back((*itr)._title);
+    _List.insertRow(_List.getRowCount(),row);
+    _indexes.push_back(itr-_data.begin());
+    u32 flags=(*itr)._flags;
+    ++itr;
+    if((flags&cParsedItem::EFolder)&&(flags&cParsedItem::EOpen)==0)
+    {
+      while(((*itr)._flags&cParsedItem::EInFolder)&&itr!=_data.end()) ++itr;
+    }
+  }
+}
+
+void CheatWnd::deselectFolder(size_t anIndex)
+{
+  std::vector<cParsedItem>::iterator itr=_data.begin()+anIndex;
+  while(--itr>=_data.begin())
+  {
+    if((*itr)._flags&cParsedItem::EFolder)
+    {
+      ++itr;
+      break;
+    }
+  }
+  while(((*itr)._flags&cParsedItem::EInFolder)&&itr!=_data.end())
+  {
+    (*itr)._flags&=~cParsedItem::ESelected;
+    ++itr;
+  }
+}
+
+std::string CheatWnd::getCheats()
+{
+  std::string cheats;
+  for(uint i=0;i< _data.size();i++)
+  {
+    if(_data[i]._flags&cParsedItem::ESelected)
+    {
+      cheats += _data[i]._cheat.substr(0, _data[i]._cheat.size()-1);
+    }
+  }
+  std::replace( cheats.begin(), cheats.end(), '\n', ' '); // replace all '\n' to ' '
+  return cheats;
+}

--- a/romsel_aktheme/arm9/source/windows/cheatwnd.h
+++ b/romsel_aktheme/arm9/source/windows/cheatwnd.h
@@ -1,0 +1,103 @@
+/*
+    cheatwnd.h
+    Copyright (C) 2009 yellow wood goblin
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __CHEATWND_H__
+#define __CHEATWND_H__
+
+#include "ui/form.h"
+#include "ui/formdesc.h"
+#include "ui/statictext.h"
+#include "ui/button.h"
+#include "ui/listview.h"
+
+class CheatWnd: public akui::Form
+{
+  public:
+    CheatWnd(s32 x,s32 y,u32 w,u32 h,Window* parent,const std::string& text);
+    ~CheatWnd();
+    bool parse(const std::string& aFileName);
+    static bool searchCheatData(FILE* aDat,u32 gamecode,u32 crc32,long& aPos,size_t& aSize);
+    static bool romData(const std::string& aFileName,u32& aGameCode,u32& aCrc32);
+  protected:
+    void draw();
+    bool process(const akui::Message& msg);
+    Window& loadAppearance(const std::string& aFileName);
+  protected:
+    bool processKeyMessage(const akui::KeyMessage& msg);
+    void onItemClicked(u32 index);
+    void onSelect(void);
+    void onDeselectAll(void);
+    void onInfo(void);
+    void onGenerate(void);
+    void onCancel(void);
+    void onDraw(const akui::ListView::OwnerDraw& data);
+    void drawMark(const akui::ListView::OwnerDraw& od,u16 width);
+    void generateList(void);
+    akui::Button _buttonDeselect;
+    akui::Button _buttonInfo;
+    akui::Button _buttonGenerate;
+    akui::Button _buttonCancel;
+    akui::FormDesc _renderDesc;
+    akui::ListView _List;
+  protected:
+    bool parseInternal(FILE* aDat,u32 gamecode,u32 crc32);
+    void deselectFolder(size_t anIndex);
+  private:
+    struct sDatIndex
+    {
+      u32 _gameCode;
+      u32 _crc32;
+      u64 _offset;
+    };
+    class cParsedItem
+    {
+      public:
+        std::string _title;
+        std::string _comment;
+        std::string _cheat;
+        u32 _flags;
+        u32 _offset;
+        cParsedItem(const std::string& title,const std::string& comment,u32 flags,u32 offset=0):_title(title),_comment(comment),_flags(flags),_offset(offset) {};
+        enum
+        {
+          EFolder=1,
+          EInFolder=2,
+          EOne=4,
+          ESelected=8,
+          EOpen=16
+        };
+    };
+    enum
+    {
+      EIconColumn=0,
+      ETextColumn=1,
+      EIconWidth=15,
+      EFolderWidth=11,
+      ERowHeight=15,
+      EFolderTop=3,
+      ESelectTop=5
+    };
+  private:
+    std::vector<cParsedItem> _data;
+    std::vector<size_t> _indexes;
+    std::string _fileName;
+  public:
+    std::string getCheats();
+};
+
+#endif

--- a/romsel_aktheme/arm9/source/windows/rominfownd.cpp
+++ b/romsel_aktheme/arm9/source/windows/rominfownd.cpp
@@ -23,6 +23,7 @@
 #include "systemfilenames.h"
 #include "ui/msgbox.h"
 #include "windows/dsiiconsequence.h"
+#include "windows/cheatwnd.h"
 #include "common/dsimenusettings.h"
 #include "common/pergamesettings.h"
 #include "ui/windowmanager.h"
@@ -37,6 +38,7 @@ RomInfoWnd::RomInfoWnd(s32 x, s32 y, u32 w, u32 h, Window *parent, const std::st
     : Form(x, y, w, h, parent, text),
       _buttonOK(0, 0, 46, 18, this, "\x01 OK"),
       _buttonGameSettings(0, 0, 76, 18, this, "\x04 Save Type"),
+      _buttonCheats(0,0,46,18,this,"\x03 Cheats"),
       _settingWnd(NULL)
 //   _saves(NULL)
 {
@@ -66,6 +68,18 @@ RomInfoWnd::RomInfoWnd(s32 x, s32 y, u32 w, u32 h, Window *parent, const std::st
     s16 nextButtonXone = nextButtonX - buttonPitch;
 
     _buttonGameSettings.setRelativePosition(Point(nextButtonXone, buttonY));
+
+    _buttonCheats.setStyle( Button::press );
+    _buttonCheats.setText( "\x03 " + LANG( "cheats", "title" ) );
+    _buttonCheats.setTextColor( uis().buttonTextColor );
+    _buttonCheats.loadAppearance( SFN_BUTTON3 );
+    _buttonCheats.clicked.connect( this, &RomInfoWnd::pressCheats );
+    addChildWindow( &_buttonCheats );
+
+    buttonPitch = _buttonCheats.size().x + 8;
+    nextButtonXone -= buttonPitch;
+
+    _buttonCheats.setRelativePosition( Point(nextButtonXone, buttonY) );
 
     loadAppearance("");
     arrangeChildren();
@@ -337,6 +351,22 @@ void RomInfoWnd::pressGameSettings(void)
     _settingWnd = NULL;
     if (ret == ID_CANCEL)
         return;
+}
+
+void RomInfoWnd::pressCheats(void)
+{
+  if(!_romInfo.isDSRom()||_romInfo.isHomebrew()) return;
+  showCheats(_fullName);
+}
+
+void RomInfoWnd::showCheats(const std::string& aFileName)
+{
+  u32 w=256;
+  u32 h=179;
+
+  // CheatWnd cheatWnd((256-w)/2,(192-h)/2,w,h,NULL,LANG("cheats","title"));
+  CheatWnd cheatWnd((256-w)/2,(192-h)/2,w,h,NULL,aFileName);
+  if(cheatWnd.parse(aFileName)) cheatWnd.doModal();
 }
 
 Window &RomInfoWnd::loadAppearance(const std::string &aFileName)

--- a/romsel_aktheme/arm9/source/windows/rominfownd.cpp
+++ b/romsel_aktheme/arm9/source/windows/rominfownd.cpp
@@ -38,7 +38,7 @@ RomInfoWnd::RomInfoWnd(s32 x, s32 y, u32 w, u32 h, Window *parent, const std::st
     : Form(x, y, w, h, parent, text),
       _buttonOK(0, 0, 46, 18, this, "\x01 OK"),
       _buttonGameSettings(0, 0, 76, 18, this, "\x04 Save Type"),
-      _buttonCheats(0,0,46,18,this,"\x03 Cheats"),
+      _buttonCheats(0, 0, 46, 18, this, "\x03 Cheats"),
       _settingWnd(NULL)
 //   _saves(NULL)
 {
@@ -70,7 +70,7 @@ RomInfoWnd::RomInfoWnd(s32 x, s32 y, u32 w, u32 h, Window *parent, const std::st
     _buttonGameSettings.setRelativePosition(Point(nextButtonXone, buttonY));
 
     _buttonCheats.setStyle( Button::press );
-    _buttonCheats.setText( "\x03 " + LANG( "cheats", "title" ) );
+    _buttonCheats.setText( "\x03 " + LANG( "cheats", "button" ) );
     _buttonCheats.setTextColor( uis().buttonTextColor );
     _buttonCheats.loadAppearance( SFN_BUTTON3 );
     _buttonCheats.clicked.connect( this, &RomInfoWnd::pressCheats );
@@ -156,17 +156,17 @@ bool RomInfoWnd::processKeyMessage(const KeyMessage &msg)
             pressGameSettings();
             ret = true;
             break;
-        // case KeyMessage::UI_KEY_X:
-        //     // if (_buttonCheats.isVisible())
-        //     // {
-        //     //     pressCheats();
-        //     // }
-        //     // else if (_buttonFlash.isVisible())
-        //     // {
-        //     //     pressFlash();
-        //     // }
-        //     ret = true;
-        //     break;
+        case KeyMessage::UI_KEY_X:
+            if (_buttonCheats.isVisible())
+            {
+                pressCheats();
+            }
+            // else if (_buttonFlash.isVisible())
+            // {
+            //     pressFlash();
+            // }
+            ret = true;
+            break;
         // case KeyMessage::UI_KEY_L:
         //     pressCopy();
         //     ret = true;
@@ -364,8 +364,7 @@ void RomInfoWnd::showCheats(const std::string& aFileName)
   u32 w=256;
   u32 h=179;
 
-  // CheatWnd cheatWnd((256-w)/2,(192-h)/2,w,h,NULL,LANG("cheats","title"));
-  CheatWnd cheatWnd((256-w)/2,(192-h)/2,w,h,NULL,aFileName);
+  CheatWnd cheatWnd((256-w)/2,(192-h)/2,w,h,NULL,LANG("cheats","title"));
   if(cheatWnd.parse(aFileName)) cheatWnd.doModal();
 }
 

--- a/romsel_aktheme/arm9/source/windows/rominfownd.h
+++ b/romsel_aktheme/arm9/source/windows/rominfownd.h
@@ -51,8 +51,9 @@ class RomInfoWnd : public akui::Form
 
     const DSRomInfo &getRomInfo();
 
-   // static void showPerGameSettings(const std::string &aFileName);
-    // static void showCheats(const std::string &aFileName);
+    // static void showPerGameSettings(const std::string &aFileName);
+    
+    static void showCheats(const std::string &aFileName);
 
   protected:
     void setDiskInfo(void);
@@ -63,7 +64,7 @@ class RomInfoWnd : public akui::Form
 
     // void pressCopy(void);
 
-    // void pressCheats(void);
+    void pressCheats(void);
 
     // void pressCopySlot(void);
 
@@ -83,7 +84,7 @@ class RomInfoWnd : public akui::Form
 
     // akui::Button _buttonCopy;
 
-    // akui::Button _buttonCheats;
+    akui::Button _buttonCheats;
 
     akui::FormDesc _renderDesc;
 

--- a/romsel_aktheme/nitrofiles/language/lang_cn/language.txt
+++ b/romsel_aktheme/nitrofiles/language/lang_cn/language.txt
@@ -25,6 +25,7 @@ ok = 确定
 cancel = 取消
 
 [cheats]
+button = 金手指
 title = 金手指
 error_title = 错误
 error_text = 没有找到金手指文件。

--- a/romsel_aktheme/nitrofiles/language/lang_de/language.txt
+++ b/romsel_aktheme/nitrofiles/language/lang_de/language.txt
@@ -25,7 +25,8 @@ ok = OK
 cancel = Abbr.
 
 [cheats]
-title = Cheats: SELECT = Auswahl speichern
+button = Cheats
+title = Cheats-Menü
 error_title = Fehler
 error_text = Cheat-Datei wurde nicht gefunden.
 selectrom = Bitte wähle eine .NDS-Datei aus

--- a/romsel_aktheme/nitrofiles/language/lang_en/language.txt
+++ b/romsel_aktheme/nitrofiles/language/lang_en/language.txt
@@ -24,7 +24,8 @@ ok = OK
 cancel = Cancel
 
 [cheats]
-title = Cheats: SELECT = Save Selection
+button = Cheats
+title = Cheats Menu
 error_title = Error
 error_text = Cheat file was not found.
 selectrom = Please select a .NDS file

--- a/romsel_aktheme/nitrofiles/language/lang_es/language.txt
+++ b/romsel_aktheme/nitrofiles/language/lang_es/language.txt
@@ -25,7 +25,8 @@ ok = OK
 cancel = Cancelar
 
 [cheats]
-title = Trucos: SELECT = Guardar
+button = Trucos
+title = Menú de Trucos
 error_title = Error: 
 error_text = No hay archivo de trucos.
 selectrom = Por favor, seleccione un archivo .NDS

--- a/romsel_aktheme/nitrofiles/language/lang_fr/language.txt
+++ b/romsel_aktheme/nitrofiles/language/lang_fr/language.txt
@@ -28,22 +28,17 @@ ok = OK
 cancel = Annuler
 
 [cheats]
-
-title = Codes triches
+button = Triches
+title = Menu codes triche
 error_title = Erreur
-
 error_text = Fichier codes triche non trouvé 
 selectrom = Sélectionnez un .NDS SVP.
-
-
-
 noxml = Fichier codes Triches XML n'a pas été trouvé 
 ccexists = .CC existe deja, Crée un nouveau ?
 nonefound = Pas de codes triches trouvé dans le fichier XML
 xmlselect = Select. fichier codes triche:
 confirm = Confirmer
 confirm_rebuild = Sauvegarder dans le fichier .CC?
-
 invalid cheatdb = Fichier code triche invalide
 Rebuild = Sauver
 Sel. DB = Choix

--- a/romsel_aktheme/nitrofiles/language/lang_it/language.txt
+++ b/romsel_aktheme/nitrofiles/language/lang_it/language.txt
@@ -25,7 +25,8 @@ ok = Ok
 cancel = Annulla
 
 [cheats]
-title = SELECT = Salva Cheats
+button = Cheats
+title = Menu cheat
 error_title = Errore
 error_text = Cheats non trovati.
 selectrom = Seleziona un file .NDS

--- a/romsel_aktheme/nitrofiles/language/lang_jp/language.txt
+++ b/romsel_aktheme/nitrofiles/language/lang_jp/language.txt
@@ -25,7 +25,8 @@ ok = 決定
 cancel = 取消し
 
 [cheats]
-title =  チートメニュー
+button = チート
+title = チートメニュー
 error_title = エラー
 error_text = チートコードが登録されていません
 selectrom = NDSファイルを選択してください

--- a/romsel_aktheme/nitrofiles/language/lang_ko/language.txt
+++ b/romsel_aktheme/nitrofiles/language/lang_ko/language.txt
@@ -24,7 +24,8 @@ ok = 확인
 cancel = 취소
 
 [cheats]
-title = 치트를 선택하신 후 SELECT를 누르세요.
+button = 치트를
+title = 치트를 메뉴
 error_title = 오류
 error_text = 치트파일이 없습니다.
 selectrom = NDS 파일을 선택해 주십시오.

--- a/romsel_aktheme/nitrofiles/language/lang_zh/language.txt
+++ b/romsel_aktheme/nitrofiles/language/lang_zh/language.txt
@@ -25,6 +25,7 @@ ok = 確定
 cancel = 取消
 
 [cheats]
+button = 金手指
 title = 金手指選擇視窗
 error_title = 錯誤
 error_text = 找不到金手指檔案


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

### The Acekard cheat UI has been restored!
- Place a `usrcheat.dat` file in `sd:/_nds/TWiLightMenu/akmenu/cheats/`, then press `Y` on a game to open its settings, then press `X` to select which cheats you want to use.

### The ability to show the current day of the week for even more customizability in your themes
- Add the file `calendar/weekday_text.bmp` to your theme folder, then add the following (with your own x/y values) to `uisettings.ini`:
```
[calendar weekday]
x = 155
y = 20
show = 1
```
- You can use a second weekday if you want too, for that you need `calendar/weekday_text_2.bmp` in your theme folder and this (w/ correct x/y) in `uisettings.ini`:
```
[calendar weekday 2]
x = 3
y = 3
show = 1
```
- *Note:* `calendar/weekday_text.bmp` and `calendar/weekday_text_2.bmp` should contain all of the days, each exactly 1/7th the height of the height of the file going `Sunday → Saturday` (top → bottom)

#### Where have you tested it?

On my DSi (J) with the latest TWiLight Menu++ / HiyaCFW / Unlaunch

*** 
#### Pull Request status
- [x]  This PR has been tested using latest devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.