### PR TITLE
Fix compilation errors in booter and rungame*

### DIFF
--- a/booter/Makefile
+++ b/booter/Makefile
@@ -131,8 +131,8 @@ dist:	all
 	
 $(TARGET).nds:	$(TARGET).arm7 $(TARGET).arm9
 	ndstool	-c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \
-			-g SRLA 01 "TWLMENUPP" -z 80040000 -u 00030004 \
-			-b icon.bmp "TWiLight Menu++;RocketRobz"
+			-g SRLA 01 "TWLMENUPP" -z 80040000 -u 00030004
+			# -b icon.bmp "TWiLight Menu++;RocketRobz"
 
 	python2 patch_ndsheader_dsiware.py $(CURDIR)/$(TARGET).nds
 

--- a/booter/Makefile
+++ b/booter/Makefile
@@ -131,9 +131,10 @@ dist:	all
 	
 $(TARGET).nds:	$(TARGET).arm7 $(TARGET).arm9
 	ndstool	-c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \
+			-g SRLA 01 "TWLMENUPP" -z 80040000 -u 00030004 \
+			-b icon.bmp "TWiLight Menu++;RocketRobz"
+
 	python2 patch_ndsheader_dsiware.py $(CURDIR)/$(TARGET).nds
-			-g SRLA 01 "TWLMENUPP" -z 80040000 -u 00030004
-			#-b icon.bmp "TWiLight Menu++;RocketRobz" \
 
 $(TARGET).arm7: arm7/$(TARGET).elf
 	cp arm7/$(TARGET).elf $(TARGET).arm7.elf

--- a/rungame/Makefile
+++ b/rungame/Makefile
@@ -131,8 +131,9 @@ dist:	all
 	
 $(TARGET).nds:	$(TARGET).arm7 $(TARGET).arm9
 	ndstool	-u 00030015 -g SLRN -c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \
-	python2 patch_ndsheader_dsiware.py $(TARGET).nds
 			-g SLRN 01 "TWLMENUPP-LR" -b icon.bmp "TWiLight Menu++;Last-run ROM;RocketRobz"
+
+	python2 patch_ndsheader_dsiware.py $(TARGET).nds
 
 $(TARGET).arm7: arm7/$(TARGET).elf
 	cp arm7/$(TARGET).elf $(TARGET).arm7.elf


### PR DESCRIPTION
<sub>*but might break something else</sub>
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

This makes it so `booter` and `rungame` compile for me on the latest devkitPro, devkitARM, (RocketRobz) libnds, ect. but I'm not sure if doing this breaks anything, `booter` seems fine for me (but I can't test on Windows), but while `rungame` compiles, it doesn't actually seem to work (but I don't have access to SDNAND menu so I can't launch it w/ Hiya).

If this doesn't break the apps (especially `rungame`) or break anything on windows this at least means `booter` compiles successfully, but **it should be tested on windows and for `rungame` on a system that can normally compile it**.

#### Where have you tested it?

- Mac running 10.14.2 with the latest dkp and dka, with the RocketRobz fork of libnds
- DSi (J) with latest TWiLight, Unlaunch, and HiyaCFW

*** 
#### Pull Request status
- [x]  This PR has been tested using latest devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
