### PR TITLE
DSi/3DS themes: Add cheat menu, R4 theme: Update cheat menu to open with X in per-game settings

### DIFF
--- a/romsel_dsimenutheme/arm9/source/cheat.h
+++ b/romsel_dsimenutheme/arm9/source/cheat.h
@@ -25,6 +25,12 @@ public:
 
 	bool romData(const std::string& aFileName,u32& aGameCode,u32& aCrc32);
 
+  void selectCheats(std::string filename);
+
+  void writeList();
+
+  void onGenerate(void);
+
 	private:
     struct sDatIndex
     {

--- a/romsel_dsimenutheme/arm9/source/perGameSettings.cpp
+++ b/romsel_dsimenutheme/arm9/source/perGameSettings.cpp
@@ -584,8 +584,7 @@ void perGameSettings (std::string filename) {
 				}
 				break;
 			}
-			if ((pressed & KEY_X))
-			{
+			if ((pressed & KEY_X)) {
 				CheatCodelist codelist;
 				codelist.selectCheats(filename);
 			}

--- a/romsel_dsimenutheme/arm9/source/perGameSettings.cpp
+++ b/romsel_dsimenutheme/arm9/source/perGameSettings.cpp
@@ -42,6 +42,7 @@
 #include "graphics/FontGraphic.h"
 #include "graphics/TextPane.h"
 #include "SwitchState.h"
+#include "cheat.h"
 
 #include "gbaswitch.h"
 #include "nds_loader_arm9.h"
@@ -411,7 +412,7 @@ void perGameSettings (std::string filename) {
 					printSmall(false, 188, 96, "Release");
 				}
 			}
-			printSmall(false, 200, 166, "B: Back");
+			printSmall(false, 135, 166, "X: Cheats B: Back");
 		}
 		do {
 			scanKeys();
@@ -582,6 +583,11 @@ void perGameSettings (std::string filename) {
 					perGameSettingsChanged = false;
 				}
 				break;
+			}
+			if ((pressed & KEY_X))
+			{
+				CheatCodelist codelist;
+				codelist.selectCheats(filename);
 			}
 		}
 	}

--- a/romsel_r4theme/arm9/source/cheat.cpp
+++ b/romsel_r4theme/arm9/source/cheat.cpp
@@ -27,8 +27,8 @@
 #include "iconTitle.h"
 #include "graphics/fontHandler.h"
 
-extern bool showdialogbox;
 extern int dialogboxHeight;
+extern bool useBootstrap;
 
 int cheatWnd_cursorPosition = 0;
 
@@ -233,7 +233,6 @@ void CheatCodelist::selectCheats(std::string filename)
 	clearText();
 
   dialogboxHeight = 6;
-	showdialogbox = true;
 
   titleUpdate(isDirectory, filename.c_str());
   printLargeCentered(false, 84, "Cheats");
@@ -373,52 +372,57 @@ void CheatCodelist::selectCheats(std::string filename)
       break;
     }
     if(pressed & KEY_X) {
+      clearText();
+      titleUpdate(isDirectory, filename.c_str());
+      printLargeCentered(false, 84, "Cheats");
+      printSmallCentered(false, 100, "Saving...");
       onGenerate();
       break;
     }
     if(pressed & KEY_Y) {
       if(_data[cheatWnd_cursorPosition]._comment != "") {
-        while(1) {
-          clearText();
-          printLargeCentered(false, 84, "Cheats");
+        clearText();
+        titleUpdate(isDirectory, filename.c_str());
+        printLargeCentered(false, 84, "Cheats");
 
-          std::vector<std::string> _topText;
-          std::string _topTextStr(_data[cheatWnd_cursorPosition]._comment);
-          std::vector<std::string> words;
-          std::size_t pos;
+        std::vector<std::string> _topText;
+        std::string _topTextStr(_data[cheatWnd_cursorPosition]._comment);
+        std::vector<std::string> words;
+        std::size_t pos;
 
-          // Process comment to stay within the box
-          while((pos = _topTextStr.find(' ')) != std::string::npos) {
-            words.push_back(_topTextStr.substr(0, pos));
-            _topTextStr = _topTextStr.substr(pos + 1);
-          }
-          if(_topTextStr.size())
-            words.push_back(_topTextStr);
-          std::string temp;
-          _topText.clear();
-          for(auto word : words)
-          {
-            int width = calcLargeFontWidth((temp + " " + word).c_str());
-            if(width > 220) {
-              _topText.push_back(temp);
-              temp = word;
-            }
-            else
-            {
-              temp += " " + word;
-            }
-          }
-          if(temp.size())
+        // Process comment to stay within the box
+        while((pos = _topTextStr.find(' ')) != std::string::npos) {
+          words.push_back(_topTextStr.substr(0, pos));
+          _topTextStr = _topTextStr.substr(pos + 1);
+        }
+        if(_topTextStr.size())
+          words.push_back(_topTextStr);
+        std::string temp;
+        _topText.clear();
+        for(auto word : words)
+        {
+          int width = calcLargeFontWidth((temp + " " + word).c_str());
+          if(width > 220) {
             _topText.push_back(temp);
-          
-          // Print comment
-          for (int i = 0; i < (int)_topText.size(); i++)
-          {
-            printSmallCentered(false, 100 + (i*8), _topText[i].c_str());
+            temp = word;
           }
+          else
+          {
+            temp += " " + word;
+          }
+        }
+        if(temp.size())
+          _topText.push_back(temp);
+        
+        // Print comment
+        for (int i = 0; i < (int)_topText.size(); i++)
+        {
+          printSmallCentered(false, 100 + (i*8), _topText[i].c_str());
+        }
 
-          // Print 'Back' text
-          printSmallCentered(false, 167, "B: Back");
+        // Print 'Back' text
+        printSmallCentered(false, 167, "B: Back");
+        while(1) {
           scanKeys();
           pressed = keysDownRepeat();
           swiWaitForVBlank();
@@ -430,8 +434,7 @@ void CheatCodelist::selectCheats(std::string filename)
     }
   }
 	clearText();
-	showdialogbox = false;
-	dialogboxHeight = 0;
+	dialogboxHeight = 4+useBootstrap;
 }
 
 static void updateDB(u8 value,u32 offset,FILE* db)

--- a/romsel_r4theme/arm9/source/cheat.cpp
+++ b/romsel_r4theme/arm9/source/cheat.cpp
@@ -297,7 +297,6 @@ void CheatCodelist::selectCheats(std::string filename)
         }
         if(i+cheatWnd_cursorPosition<(int)_data.size()) {
           if(_data[i+cheatWnd_cursorPosition]._flags&cParsedItem::ESelected) {
-            printf ("\x1B[42m");
             printSmall(false, textX-14, 99+(i*8), "x");
           }
           if(i==0) {

--- a/romsel_r4theme/arm9/source/fileBrowse.cpp
+++ b/romsel_r4theme/arm9/source/fileBrowse.cpp
@@ -44,7 +44,6 @@
 #include "graphics/TextPane.h"
 #include "SwitchState.h"
 #include "perGameSettings.h"
-#include "cheat.h"
 
 #include "gbaswitch.h"
 #include "nds_loader_arm9.h"
@@ -477,12 +476,6 @@ string browseForFile(const vector<string> extensionList, const char* username)
 			SaveSettings();
 			settingsChanged = false;
 			return "null";		
-		}
-
-		if ((pressed & KEY_L))
-		{
-			CheatCodelist codelist;
-			codelist.selectCheats(dirContents.at(fileOffset).name);
 		}
 
 		if ((pressed & KEY_B) && showDirectories) {

--- a/romsel_r4theme/arm9/source/perGameSettings.cpp
+++ b/romsel_r4theme/arm9/source/perGameSettings.cpp
@@ -42,6 +42,7 @@
 #include "graphics/FontGraphic.h"
 #include "graphics/TextPane.h"
 #include "SwitchState.h"
+#include "cheat.h"
 
 #include "gbaswitch.h"
 #include "nds_loader_arm9.h"
@@ -412,7 +413,7 @@ void perGameSettings (std::string filename) {
 					printSmall(false, 180, 144, "Release");
 				}
 			}
-			printSmallCentered(false, 150+(useBootstrap*8), "B: Back");
+			printSmallCentered(false, 150+(useBootstrap*8), "X: Cheats B: Back");
 		}
 		do {
 			scanKeys();
@@ -581,6 +582,10 @@ void perGameSettings (std::string filename) {
 					perGameSettingsChanged = false;
 				}
 				break;
+			}
+			if ((pressed & KEY_X)) {
+				CheatCodelist codelist;
+				codelist.selectCheats(filename);
 			}
 		}
 	}


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Adds a cheat menu to the DSi and 3DS themes
- *Note: This isn't perfectly stable. For some reason despite working fine on the R4 theme I sometimes get Guru Meditation Errors in the DSi/3DS themes, but it usually works fine and I can't figure out how to do it better*
- Updates the R4 theme cheat menu to be `X` in per-game settings to match the other themes

#### Where have you tested it?

DSi (J) with latest Hiya/TWiLight/Unlaunch

*** 
#### Pull Request status
- [x]  This PR has been tested using latest devkitPro, devkitARM, and EasyGL2D.

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
