### PR TITLE
Add support for “Simple Dark” and “Simple Light” loading screens

### DIFF
--- a/settings/arm9/source/bootstrapsettings.h
+++ b/settings/arm9/source/bootstrapsettings.h
@@ -27,7 +27,9 @@ class BootstrapSettings
         ELoadingNone = 0,
         ELoadingRegular = 1,
         ELoadingPong = 2,
-        ELoadingTicTacToe = 3
+        ELoadingTicTacToe = 3,
+	ELoadingSimpleLight = 4,
+	ELoadingSimpleDark = 5
     };
 
   public:

--- a/settings/arm9/source/main.cpp
+++ b/settings/arm9/source/main.cpp
@@ -566,7 +566,7 @@ SettingsPage mainPage(STR_MAIN_SETTINGS);
 	gamesPage
 		.option(STR_LOADINGSCREEN, STR_DESCRIPTION_LOADINGSCREEN_1,
 				Option::Int(&bs().bstrap_loadingScreen),
-				{STR_NONE, STR_REGULAR, "Pong", "Tic-Tac-Toe", "Simple Light" "Simple Dark"},
+				{STR_NONE, STR_REGULAR, "Pong", "Tic-Tac-Toe", "Simple Light", "Simple Dark"},
 				{TLoadingScreen::ELoadingNone,
 				 TLoadingScreen::ELoadingRegular,
 				 TLoadingScreen::ELoadingPong,

--- a/settings/arm9/source/main.cpp
+++ b/settings/arm9/source/main.cpp
@@ -571,7 +571,7 @@ SettingsPage mainPage(STR_MAIN_SETTINGS);
 				 TLoadingScreen::ELoadingRegular,
 				 TLoadingScreen::ELoadingPong,
 				 TLoadingScreen::ELoadingTicTacToe,
-				 TLoadingScreen::ELoadingSimpleLight
+				 TLoadingScreen::ELoadingSimpleLight,
 				 TLoadingScreen::ELoadingSimpleDark})
 
 		.option(STR_BOOTSTRAP, STR_DESCRIPTION_BOOTSTRAP_1,

--- a/settings/arm9/source/main.cpp
+++ b/settings/arm9/source/main.cpp
@@ -566,11 +566,13 @@ SettingsPage mainPage(STR_MAIN_SETTINGS);
 	gamesPage
 		.option(STR_LOADINGSCREEN, STR_DESCRIPTION_LOADINGSCREEN_1,
 				Option::Int(&bs().bstrap_loadingScreen),
-				{STR_NONE, STR_REGULAR, "Pong", "Tic-Tac-Toe"},
+				{STR_NONE, STR_REGULAR, "Pong", "Tic-Tac-Toe", "Simple Light" "Simple Dark"},
 				{TLoadingScreen::ELoadingNone,
 				 TLoadingScreen::ELoadingRegular,
 				 TLoadingScreen::ELoadingPong,
-				 TLoadingScreen::ELoadingTicTacToe})
+				 TLoadingScreen::ELoadingTicTacToe,
+				 TLoadingScreen::ELoadingSimpleLight
+				 TLoadingScreen::ELoadingSimpleDark})
 
 		.option(STR_BOOTSTRAP, STR_DESCRIPTION_BOOTSTRAP_1,
 				Option::Bool(&ms().bootstrapFile),


### PR DESCRIPTION
Wait for my nds-bootstrap PR too