### PR TITLE
DSi theme: Set randomizer seed before randomizing

### DIFF
--- a/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
@@ -1597,8 +1597,8 @@ void graphicsInit()
 	REG_BG3PD_SUB = 1<<8;
 
 	if (theme < 1) {
-		loadPhotoList();
 		srand(time(NULL));
+		loadPhotoList();
 		loadPhoto();
 	}
 


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- It was setting the randomizer seed after calling generating the number, meaning it would always be the same

#### Where have you tested it?

DSi (J) with the latest TWiLight, HiyaCFW, and Unlaunch

*** 
#### Pull Request status
- [x]  This PR has been tested using latest devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.