### PR TITLE
Added suppot for extended ascii characters

### DIFF
--- a/settings/arm9/source/language.cpp
+++ b/settings/arm9/source/language.cpp
@@ -4,6 +4,7 @@
 #include <sys/stat.h>
 #include <string.h>
 #include <unistd.h>
+#include <string>
 
 #include "common/inifile.h"
 #include "common/dsimenusettings.h"
@@ -189,6 +190,19 @@ const char *languageIniPath;
 
 int setLanguage = 0;
 
+std::string ReplaceExtASCII(const std::string& input) {
+	std::string res;
+	for(size_t i = 0; i < input.size(); i++) {
+		if(i < input.size() - 3 && (i == 0 || input[i - 1] != '\\') && input[i] == '\\' && (input[i + 1] == 'x' || input[i + 1] == 'X')) {
+			int c = std::stoi(input.substr(i + 2, i + 2), 0, 16);
+			res += (char)c;
+			i += 3;
+		} else
+			res += input[i];
+	}
+	return res;
+}
+
 /**
  * Initialize translations.
  * Uses the language ID specified in settings.ui.language.
@@ -220,185 +234,185 @@ void langInit(void)
 
 	CIniFile languageini(languageIniPath);
 
-	STR_SAVING_SETTINGS = languageini.GetString("LANGUAGE", "SAVING_SETTINGS", "Saving settings...");
-	STR_SETTINGS_SAVED = languageini.GetString("LANGUAGE", "SETTINGS_SAVED", "Settings saved.");
+	STR_SAVING_SETTINGS = ReplaceExtASCII(languageini.GetString("LANGUAGE", "SAVING_SETTINGS", "Saving settings..."));
+	STR_SETTINGS_SAVED = ReplaceExtASCII(languageini.GetString("LANGUAGE", "SETTINGS_SAVED", "Settings saved."));
 
-	STR_LR_SWITCH = languageini.GetString("LANGUAGE", "LR_SWITCH", "L/R/Y/X Switch Pages");
-	STR_MISC_SETTINGS = languageini.GetString("LANGUAGE", "MISC_SETTINGS", "Misc. Settings");
-	STR_GUI_SETTINGS = languageini.GetString("LANGUAGE", "GUI_SETTINGS", "GUI Settings");
-	STR_GAMESAPPS_SETTINGS = languageini.GetString("LANGUAGE", "GAMESAPPS_SETTINGS", "Games and Apps Settings");
+	STR_LR_SWITCH = ReplaceExtASCII(languageini.GetString("LANGUAGE", "LR_SWITCH", "L/R/Y/X Switch Pages"));
+	STR_MISC_SETTINGS = ReplaceExtASCII(languageini.GetString("LANGUAGE", "MISC_SETTINGS", "Misc. Settings"));
+	STR_GUI_SETTINGS = ReplaceExtASCII(languageini.GetString("LANGUAGE", "GUI_SETTINGS", "GUI Settings"));
+	STR_GAMESAPPS_SETTINGS = ReplaceExtASCII(languageini.GetString("LANGUAGE", "GAMESAPPS_SETTINGS", "Games and Apps Settings"));
 
 	// GUI settings
-	STR_S1SDACCESS = languageini.GetString("LANGUAGE", "S1SDACCESS", "Slot-1 microSD access");
-	STR_MAINMENU = languageini.GetString("LANGUAGE", "MAINMENU", "Main Menu");
-	STR_THEME = languageini.GetString("LANGUAGE", "THEME", "Theme");
-	STR_LASTPLAYEDROM = languageini.GetString("LANGUAGE", "LASTPLAYEDROM", "Last played ROM on startup.");
-	STR_DSIMENUPPLOGO = languageini.GetString("LANGUAGE", "DSIMENUPPLOGO", "TWLMenu++ Splash Screen");
-	STR_DIRECTORIES = languageini.GetString("LANGUAGE", "DIRECTORIES", "Directories/Folders");
-	STR_BOXART = languageini.GetString("LANGUAGE", "BOXART", "Box art/Game covers");
-	STR_ANIMATEDSIICONS = languageini.GetString("LANGUAGE", "ANIMATEDSIICONS", "Animate DSi icons");
-	STR_SYSREGION = languageini.GetString("LANGUAGE", "SYSREGION", "SysNAND Region");
-	STR_LAUNCHERAPP = languageini.GetString("LANGUAGE", "LAUNCHERAPP", "SysNAND Launcher");
-	STR_SYSTEMSETTINGS = languageini.GetString("LANGUAGE", "SYSTEMSETTINGS", "System Settings");
-	STR_REPLACEDSIMENU = languageini.GetString("LANGUAGE", "REPLACEDSIMENU", "Replace DSi Menu");
-	STR_RESTOREDSIMENU = languageini.GetString("LANGUAGE", "RESTOREDSIMENU", "Restore DSi Menu");
+	STR_S1SDACCESS = ReplaceExtASCII(languageini.GetString("LANGUAGE", "S1SDACCESS", "Slot-1 microSD access"));
+	STR_MAINMENU = ReplaceExtASCII(languageini.GetString("LANGUAGE", "MAINMENU", "Main Menu"));
+	STR_THEME = ReplaceExtASCII(languageini.GetString("LANGUAGE", "THEME", "Theme"));
+	STR_LASTPLAYEDROM = ReplaceExtASCII(languageini.GetString("LANGUAGE", "LASTPLAYEDROM", "Last played ROM on startup."));
+	STR_DSIMENUPPLOGO = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DSIMENUPPLOGO", "TWLMenu++ Splash Screen"));
+	STR_DIRECTORIES = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DIRECTORIES", "Directories/Folders"));
+	STR_BOXART = ReplaceExtASCII(languageini.GetString("LANGUAGE", "BOXART", "Box art/Game covers"));
+	STR_ANIMATEDSIICONS = ReplaceExtASCII(languageini.GetString("LANGUAGE", "ANIMATEDSIICONS", "Animate DSi icons"));
+	STR_SYSREGION = ReplaceExtASCII(languageini.GetString("LANGUAGE", "SYSREGION", "SysNAND Region"));
+	STR_LAUNCHERAPP = ReplaceExtASCII(languageini.GetString("LANGUAGE", "LAUNCHERAPP", "SysNAND Launcher"));
+	STR_SYSTEMSETTINGS = ReplaceExtASCII(languageini.GetString("LANGUAGE", "SYSTEMSETTINGS", "System Settings"));
+	STR_REPLACEDSIMENU = ReplaceExtASCII(languageini.GetString("LANGUAGE", "REPLACEDSIMENU", "Replace DSi Menu"));
+	STR_RESTOREDSIMENU = ReplaceExtASCII(languageini.GetString("LANGUAGE", "RESTOREDSIMENU", "Restore DSi Menu"));
 
-	STR_SHOW = languageini.GetString("LANGUAGE", "SHOW", "Show");
-	STR_HIDE = languageini.GetString("LANGUAGE", "HIDE", "Hide");
+	STR_SHOW = ReplaceExtASCII(languageini.GetString("LANGUAGE", "SHOW", "Show"));
+	STR_HIDE = ReplaceExtASCII(languageini.GetString("LANGUAGE", "HIDE", "Hide"));
 
-	STR_DESCRIPTION_S1SDACCESS_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_S1SDACCESS_1", "Allows your flashcard to be used as a secondary device. Turn this off, if IR functionality doesn't work, or if the app crashes.");
+	STR_DESCRIPTION_S1SDACCESS_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_S1SDACCESS_1", "Allows your flashcard to be used as a secondary device. Turn this off, if IR functionality doesn't work, or if the app crashes."));
 
-	STR_DESCRIPTION_MAINMENU = languageini.GetString("LANGUAGE", "DESCRIPTION_MAINMENU", "The menu that is shown before the ROM select menu. Has the look of the original DS UI.");
+	STR_DESCRIPTION_MAINMENU = ReplaceExtASCII(languageini.GetString("LANGUAGE", "STR_DESCRIPTION_MAINMENU", "The menu that is shown before the ROM select menu. Has the look of the original DS UI."));
 
-	STR_DESCRIPTION_THEME_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_THEME_1", "The theme to use in TWiLight Menu++. Press Left/Right to select, A for sub-themes.");
+	STR_DESCRIPTION_THEME_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_THEME_1", "The theme to use in TWiLight Menu++. Press Left/Right to select, A for sub-themes."));
 
-	STR_DESCRIPTION_LASTPLAYEDROM_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_LASTPLAYEDROM_1", "If turned on, hold B on startup to skip to the ROM select menu.");
+	STR_DESCRIPTION_LASTPLAYEDROM_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_LASTPLAYEDROM_1", "If turned on, hold B on startup to skip to the ROM select menu."));
 
-	STR_DESCRIPTION_DSIMENUPPLOGO_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_DSIMENUPPLOGO_1", "The logo will be shown when you start TWiLight Menu++.");
+	STR_DESCRIPTION_DSIMENUPPLOGO_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_DSIMENUPPLOGO_1", "The logo will be shown when you start TWiLight Menu++."));
 
-	STR_DESCRIPTION_DIRECTORIES_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_DIRECTORIES_1", "If you're in a folder where most of your games are, it is safe to hide directories/folders.");
+	STR_DESCRIPTION_DIRECTORIES_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_DIRECTORIES_1", "If you're in a folder where most of your games are, it is safe to hide directories/folders."));
 
-	STR_DESCRIPTION_BOXART_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_BOXART_1", "Displayed in the top screen of the DSi/3DS theme.");
+	STR_DESCRIPTION_BOXART_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_BOXART_1", "Displayed in the top screen of the DSi/3DS theme."));
 
-	STR_DESCRIPTION_ANIMATEDSIICONS_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_ANIMATEDSIICONS_1", "Animate DSi-enhanced icons like in the DSi/3DS menus.");
+	STR_DESCRIPTION_ANIMATEDSIICONS_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_ANIMATEDSIICONS_1", "Animate DSi-enhanced icons like in the DSi/3DS menus."));
 
-	STR_DESCRIPTION_SYSREGION_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_SYSREGION", "The region of SysNAND. \"Auto\" option will only work if SDNAND is set up.");
+	STR_DESCRIPTION_SYSREGION_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_SYSREGION", "The region of SysNAND. \"Auto\" option will only work if SDNAND is set up."));
 
-	STR_DESCRIPTION_LAUNCHERAPP_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_LAUNCHERAPP", "To get the .app name, press POWER, hold A, then highlight LAUNCHER.");
+	STR_DESCRIPTION_LAUNCHERAPP_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_LAUNCHERAPP", "To get the .app name, press POWER, hold A, then highlight LAUNCHER."));
 
-	STR_DESCRIPTION_SYSTEMSETTINGS_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_SYSTEMSETTINGS_1", "Press A to change settings related to the DSi system.");
+	STR_DESCRIPTION_SYSTEMSETTINGS_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_SYSTEMSETTINGS_1", "Press A to change settings related to the DSi system."));
 
-	STR_DESCRIPTION_REPLACEDSIMENU_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_REPLACEDSIMENU_1", "Start TWiLight Menu++ on boot, instead of the DSi Menu.");
+	STR_DESCRIPTION_REPLACEDSIMENU_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_REPLACEDSIMENU_1", "Start TWiLight Menu++ on boot, instead of the DSi Menu."));
 
-	STR_DESCRIPTION_RESTOREDSIMENU_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_RESTOREDSIMENU_1", "Show DSi Menu on boot again.");
+	STR_DESCRIPTION_RESTOREDSIMENU_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_RESTOREDSIMENU_1", "Show DSi Menu on boot again."));
 
 	// Games/Apps settings
-	STR_LANGUAGE = languageini.GetString("LANGUAGE", "LANGUAGE", "Language");
-	STR_CPUSPEED = languageini.GetString("LANGUAGE", "CPUSPEED", "ARM9 CPU Speed");
-	STR_VRAMBOOST = languageini.GetString("LANGUAGE", "VRAMBOOST", "VRAM boost");
-	STR_USEBOOTSTRAP = languageini.GetString("LANGUAGE", "USEBOOTSTRAP", "Use nds-bootstrap");
-	STR_DEBUG = languageini.GetString("LANGUAGE", "DEBUG", "Debug");
-	STR_LOGGING = languageini.GetString("LANGUAGE", "LOGGING", "Logging");
-	STR_ROMREADLED = languageini.GetString("LANGUAGE", "ROMREADLED", "ROM read LED");
-	STR_RUNIN = languageini.GetString("LANGUAGE", "RUNIN", "Run in");
-	STR_SLOT1SCFGUNLOCK = languageini.GetString("LANGUAGE", "SLOT1SCFGUNLOCK", "SCFG access in Slot-1");
-	STR_SNDFREQ = languageini.GetString("LANGUAGE", "SNDFREQ", "Sound/Mic frequency");
-	STR_SLOT1LAUNCHMETHOD = languageini.GetString("LANGUAGE", "SLOT1LAUNCHMETHOD", "Slot-1 launch method");
-	STR_LOADINGSCREEN = languageini.GetString("LANGUAGE", "LOADINGSCREEN", "Loading screen");
-	STR_LOADINGSCREENTHEME = languageini.GetString("LANGUAGE", "LOADINGSCREENTHEME", "Loading screen theme");
-	STR_LOADINGSCREENLOCATION = languageini.GetString("LANGUAGE", "LOADINGSCREENLOCATION", "Loading screen location");
-	STR_BOOTSTRAP = languageini.GetString("LANGUAGE", "BOOTSTRAP", "Bootstrap");
-	STR_USEGBARUNNER2 = languageini.GetString("LANGUAGE", "USEGBARUNNER2", "Use GBARunner2");
+	STR_LANGUAGE = ReplaceExtASCII(languageini.GetString("LANGUAGE", "LANGUAGE", "Language"));
+	STR_CPUSPEED = ReplaceExtASCII(languageini.GetString("LANGUAGE", "CPUSPEED", "ARM9 CPU Speed"));
+	STR_VRAMBOOST = ReplaceExtASCII(languageini.GetString("LANGUAGE", "VRAMBOOST", "VRAM boost"));
+	STR_USEBOOTSTRAP = ReplaceExtASCII(languageini.GetString("LANGUAGE", "USEBOOTSTRAP", "Use nds-bootstrap"));
+	STR_DEBUG = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DEBUG", "Debug"));
+	STR_LOGGING = ReplaceExtASCII(languageini.GetString("LANGUAGE", "LOGGING", "Logging"));
+	STR_ROMREADLED = ReplaceExtASCII(languageini.GetString("LANGUAGE", "ROMREADLED", "ROM read LED"));
+	STR_RUNIN = ReplaceExtASCII(languageini.GetString("LANGUAGE", "RUNIN", "Run in"));
+	STR_SLOT1SCFGUNLOCK = ReplaceExtASCII(languageini.GetString("LANGUAGE", "SLOT1SCFGUNLOCK", "SCFG access in Slot-1"));
+	STR_SNDFREQ = ReplaceExtASCII(languageini.GetString("LANGUAGE", "SNDFREQ", "Sound/Mic frequency"));
+	STR_SLOT1LAUNCHMETHOD = ReplaceExtASCII(languageini.GetString("LANGUAGE", "SLOT1LAUNCHMETHOD", "Slot-1 launch method"));
+	STR_LOADINGSCREEN = ReplaceExtASCII(languageini.GetString("LANGUAGE", "LOADINGSCREEN", "Loading screen"));
+	STR_LOADINGSCREENTHEME = ReplaceExtASCII(languageini.GetString("LANGUAGE", "LOADINGSCREENTHEME", "Loading screen theme"));
+	STR_LOADINGSCREENLOCATION = ReplaceExtASCII(languageini.GetString("LANGUAGE", "LOADINGSCREENLOCATION", "Loading screen location"));
+	STR_BOOTSTRAP = ReplaceExtASCII(languageini.GetString("LANGUAGE", "BOOTSTRAP", "Bootstrap"));
+	STR_USEGBARUNNER2 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "USEGBARUNNER2", "Use GBARunner2"));
 
-	STR_SYSTEM = languageini.GetString("LANGUAGE", "SYSTEM", "System");
-	STR_ON = languageini.GetString("LANGUAGE", "ON", "On");
-	STR_OFF = languageini.GetString("LANGUAGE", "OFF", "Off");
-	STR_YES = languageini.GetString("LANGUAGE", "YES", "Yes");
-	STR_NO = languageini.GetString("LANGUAGE", "NO", "No");
-	STR_NONE = languageini.GetString("LANGUAGE", "NONE", "None");
-	STR_POWER = languageini.GetString("LANGUAGE", "POWER", "Power");
-	STR_CAMERA = languageini.GetString("LANGUAGE", "CAMERA", "Camera");
-	STR_REBOOT = languageini.GetString("LANGUAGE", "REBOOT", "Reboot");
-	STR_DIRECT = languageini.GetString("LANGUAGE", "DIRECT", "Direct");
-	STR_REGULAR = languageini.GetString("LANGUAGE", "REGULAR", "Regular");
-	STR_DARK = languageini.GetString("LANGUAGE", "DARK", "Dark");
-	STR_LIGHT = languageini.GetString("LANGUAGE", "LIGHT", "Light");
-	STR_BOTTOM = languageini.GetString("LANGUAGE", "BOTTOM", "Bottom");
-	STR_TOP = languageini.GetString("LANGUAGE", "TOP", "Top");
-	STR_RELEASE = languageini.GetString("LANGUAGE", "RELEASE", "Release");
-	STR_NIGHTLY = languageini.GetString("LANGUAGE", "NIGHTLY", "Nightly");
+	STR_SYSTEM = ReplaceExtASCII(languageini.GetString("LANGUAGE", "SYSTEM", "System"));
+	STR_ON = ReplaceExtASCII(languageini.GetString("LANGUAGE", "ON", "On"));
+	STR_OFF = ReplaceExtASCII(languageini.GetString("LANGUAGE", "OFF", "Off"));
+	STR_YES = ReplaceExtASCII(languageini.GetString("LANGUAGE", "YES", "Yes"));
+	STR_NO = ReplaceExtASCII(languageini.GetString("LANGUAGE", "NO", "No"));
+	STR_NONE = ReplaceExtASCII(languageini.GetString("LANGUAGE", "NONE", "None"));
+	STR_POWER = ReplaceExtASCII(languageini.GetString("LANGUAGE", "POWER", "Power"));
+	STR_CAMERA = ReplaceExtASCII(languageini.GetString("LANGUAGE", "CAMERA", "Camera"));
+	STR_REBOOT = ReplaceExtASCII(languageini.GetString("LANGUAGE", "REBOOT", "Reboot"));
+	STR_DIRECT = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DIRECT", "Direct"));
+	STR_REGULAR = ReplaceExtASCII(languageini.GetString("LANGUAGE", "REGULAR", "Regular"));
+	STR_DARK = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DARK", "Dark"));
+	STR_LIGHT = ReplaceExtASCII(languageini.GetString("LANGUAGE", "LIGHT", "Light"));
+	STR_BOTTOM = ReplaceExtASCII(languageini.GetString("LANGUAGE", "BOTTOM", "Bottom"));
+	STR_TOP = ReplaceExtASCII(languageini.GetString("LANGUAGE", "TOP", "Top"));
+	STR_RELEASE = ReplaceExtASCII(languageini.GetString("LANGUAGE", "RELEASE", "Release"));
+	STR_NIGHTLY = ReplaceExtASCII(languageini.GetString("LANGUAGE", "NIGHTLY", "Nightly"));
 
-	STR_DESCRIPTION_LANGUAGE_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_LANGUAGE_1", "Avoid the limited selections of your console language by setting this option.");
+	STR_DESCRIPTION_LANGUAGE_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_LANGUAGE_1", "Avoid the limited selections of your console language by setting this option."));
 
-	STR_DESCRIPTION_RUNIN_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_RUNIN_1", "Run in either DS or DSi mode.");
+	STR_DESCRIPTION_RUNIN_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_RUNIN_1", "Run in either DS or DSi mode."));
 
-	STR_DESCRIPTION_CPUSPEED_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_CPUSPEED_1", "Set to TWL to get rid of lags in some games.");
+	STR_DESCRIPTION_CPUSPEED_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_CPUSPEED_1", "Set to TWL to get rid of lags in some games."));
 
-	STR_DESCRIPTION_VRAMBOOST_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_VRAMBOOST_1", "Allow 8 bit VRAM writes and expands the bus to 32 bit.");
+	STR_DESCRIPTION_VRAMBOOST_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_VRAMBOOST_1", "Allow 8 bit VRAM writes and expands the bus to 32 bit."));
 
-	STR_DESCRIPTION_SLOT1SCFGUNLOCK = languageini.GetString("LANGUAGE", "DESCRIPTION_SLOT1SCFGUNLOCK", "Have access to SCFG while running a Slot-1 flashcard. Allows setting extended memory mode and/or clock speed in flashcard homebrew.");
+	STR_DESCRIPTION_SLOT1SCFGUNLOCK = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_SLOT1SCFGUNLOCK", "Have access to SCFG while running a Slot-1 flashcard. Allows setting extended memory mode and/or clock speed in flashcard homebrew."));
 
-	STR_DESCRIPTION_USEBOOTSTRAP = languageini.GetString("LANGUAGE", "DESCRIPTION_USEBOOTSTRAP", "nds-bootstrap is used instead of the flashcard kernel or firmware.");
+	STR_DESCRIPTION_USEBOOTSTRAP = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_USEBOOTSTRAP", "nds-bootstrap is used instead of the flashcard kernel or firmware."));
 
-	STR_DESCRIPTION_DEBUG_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_DEBUG_1", "Displays some text before launched game.");
+	STR_DESCRIPTION_DEBUG_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_DEBUG_1", "Displays some text before launched game."));
 
-	STR_DESCRIPTION_LOGGING_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_LOGGING_1", "Logs the process of patching to sd:/NDSBTSRP.LOG");
+	STR_DESCRIPTION_LOGGING_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_LOGGING_1", "Logs the process of patching to sd:/NDSBTSRP.LOG"));
 
-	STR_DESCRIPTION_ROMREADLED_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_ROMREADLED_1", "Sets LED as ROM read indicator.");
+	STR_DESCRIPTION_ROMREADLED_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_ROMREADLED_1", "Sets LED as ROM read indicator."));
 
-	STR_DESCRIPTION_SNDFREQ_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_SNDFREQ_1", "32.73kHz is original quality, 47.61kHz is high quality. Will not persist when soft-resetting, or launching last-run ROM.");
+	STR_DESCRIPTION_SNDFREQ_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_SNDFREQ_1", "32.73kHz is original quality, 47.61kHz is high quality. Will not persist when soft-resetting, or launching last-run ROM."));
 
-	STR_DESCRIPTION_SLOT1LAUNCHMETHOD_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_SLOT1LAUNCHMETHOD_1",
-																"Change this if some Slot-1 cards are not booting. Please note the reboot method will not use your set language or CPU speed.");
+	STR_DESCRIPTION_SLOT1LAUNCHMETHOD_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_SLOT1LAUNCHMETHOD_1",
+																"Change this if some Slot-1 cards are not booting. Please note the reboot method will not use your set language or CPU speed."));
 
-	STR_DESCRIPTION_LOADINGSCREEN_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_LOADINGSCREEN_1", "Shows a loading screen before ROM is started in nds-bootstrap");
+	STR_DESCRIPTION_LOADINGSCREEN_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_LOADINGSCREEN_1", "Shows a loading screen before ROM is started in nds-bootstrap"));
 
-	STR_DESCRIPTION_LOADINGSCREENTHEME = languageini.GetString("LANGUAGE", "DESCRIPTION_LOADINGSCREENTHEME", "Choose the loading screen to be light or dark.");
+	STR_DESCRIPTION_LOADINGSCREENTHEME = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_LOADINGSCREENTHEME", "Choose the loading screen to be light or dark."));
 
-	STR_DESCRIPTION_LOADINGSCREENLOCATION = languageini.GetString("LANGUAGE", "DESCRIPTION_LOADINGSCREENLOCATION", "Show the loading screen on either the top or botton screen.");
+	STR_DESCRIPTION_LOADINGSCREENLOCATION = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_LOADINGSCREENLOCATION", "Show the loading screen on either the top or botton screen."));
 
-	STR_DESCRIPTION_BOOTSTRAP_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_BOOTSTRAP_1", "Pick release or nightly bootstrap");
+	STR_DESCRIPTION_BOOTSTRAP_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_BOOTSTRAP_1", "Pick release or nightly bootstrap"));
 
-	STR_DESCRIPTION_FLASHCARD_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_FLASHCARD_1", "");
+	STR_DESCRIPTION_FLASHCARD_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_FLASHCARD_1", ""));
 
-	STR_DESCRIPTION_GBARUNNER2_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_GBARUNNER2_1", "");
+	STR_DESCRIPTION_GBARUNNER2_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_GBARUNNER2_1", ""));
 
 	// Flashcard settings
-	STR_FLASHCARD_SELECT = languageini.GetString("LANGUAGE", "FLASHCARD_SELECT", "Select Flashcard");
-	STR_LEFTRIGHT_FLASHCARD = languageini.GetString("LANGUAGE", "LEFTRIGHT_FLASHCARD", "");
-	STR_AB_SETRETURN = languageini.GetString("LANGUAGE", "AB_SETRETURN", "A/B: Set and Return");
+	STR_FLASHCARD_SELECT = ReplaceExtASCII(languageini.GetString("LANGUAGE", "FLASHCARD_SELECT", "Select Flashcard"));
+	STR_LEFTRIGHT_FLASHCARD = ReplaceExtASCII(languageini.GetString("LANGUAGE", "LEFTRIGHT_FLASHCARD", ""));
+	STR_AB_SETRETURN = ReplaceExtASCII(languageini.GetString("LANGUAGE", "AB_SETRETURN", "A/B: Set and Return"));
 
 	// Sub-theme select
-	STR_SUBTHEMESEL_DSI = languageini.GetString("LANGUAGE", "SUBTHEMESEL_DSI", "Sub-theme select: DSi Menu");
+	STR_SUBTHEMESEL_DSI = ReplaceExtASCII(languageini.GetString("LANGUAGE", "SUBTHEMESEL_DSI", "Sub-theme select: DSi Menu"));
 
-	STR_SUBTHEMESEL_R4 = languageini.GetString("LANGUAGE", "SUBTHEMESEL_R4", "Sub-theme select: R4");
-	STR_SUBTHEMESEL_AK = languageini.GetString("LANGUAGE", "SUBTHEMESEL_AK", "Sub-theme select: Acekard Menu");
+	STR_SUBTHEMESEL_R4 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "SUBTHEMESEL_R4", "Sub-theme select: R4"));
+	STR_SUBTHEMESEL_AK = ReplaceExtASCII(languageini.GetString("LANGUAGE", "SUBTHEMESEL_AK", "Sub-theme select: Acekard Menu"));
 
-	STR_AB_SETSUBTHEME = languageini.GetString("LANGUAGE", "AB_SETSUBTHEME", "A/B: Set sub-theme");
-	STR_DSI_DARKMENU = languageini.GetString("LANGUAGE", "DSI_DARKMENU", "SD/Black");
-	STR_DSI_NORMALMENU = languageini.GetString("LANGUAGE", "DSI_NORMALMENU", "Normal/White");
-	STR_DSI_RED = languageini.GetString("LANGUAGE", "DSI_RED", "Red");
-	STR_DSI_BLUE = languageini.GetString("LANGUAGE", "DSI_BLUE", "Blue");
-	STR_DSI_GREEN = languageini.GetString("LANGUAGE", "DSI_GREEN", "Green");
-	STR_DSI_YELLOW = languageini.GetString("LANGUAGE", "DSI_YELLOW", "Yellow");
-	STR_DSI_PINK = languageini.GetString("LANGUAGE", "DSI_PINK", "Pink");
-	STR_DSI_PURPLE = languageini.GetString("LANGUAGE", "DSI_PURPLE", "Purple");
-	STR_R4_THEME01 = languageini.GetString("LANGUAGE", "R4_THEME01", "Snow hill");
-	STR_R4_THEME02 = languageini.GetString("LANGUAGE", "R4_THEME02", "Snow land");
-	STR_R4_THEME03 = languageini.GetString("LANGUAGE", "R4_THEME03", "Green leaf");
-	STR_R4_THEME04 = languageini.GetString("LANGUAGE", "R4_THEME04", "Pink flower");
-	STR_R4_THEME05 = languageini.GetString("LANGUAGE", "R4_THEME05", "Park");
-	STR_R4_THEME06 = languageini.GetString("LANGUAGE", "R4_THEME06", "Cherry blossoms");
-	STR_R4_THEME07 = languageini.GetString("LANGUAGE", "R4_THEME07", "Beach");
-	STR_R4_THEME08 = languageini.GetString("LANGUAGE", "R4_THEME08", "Summer sky");
-	STR_R4_THEME09 = languageini.GetString("LANGUAGE", "R4_THEME09", "River");
-	STR_R4_THEME10 = languageini.GetString("LANGUAGE", "R4_THEME10", "Fall trees");
-	STR_R4_THEME11 = languageini.GetString("LANGUAGE", "R4_THEME11", "Christmas tree");
-	STR_R4_THEME12 = languageini.GetString("LANGUAGE", "R4_THEME12", "Drawn symbol");
-	STR_R4_THEME13 = languageini.GetString("LANGUAGE", "R4_THEME13", "Blue moon");
-	STR_R4_THEME14 = languageini.GetString("LANGUAGE", "R4_THEME14", "Mac-like");
+	STR_AB_SETSUBTHEME = ReplaceExtASCII(languageini.GetString("LANGUAGE", "AB_SETSUBTHEME", "A/B: Set sub-theme"));
+	STR_DSI_DARKMENU = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DSI_DARKMENU", "SD/Black"));
+	STR_DSI_NORMALMENU = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DSI_NORMALMENU", "Normal/White"));
+	STR_DSI_RED = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DSI_RED", "Red"));
+	STR_DSI_BLUE = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DSI_BLUE", "Blue"));
+	STR_DSI_GREEN = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DSI_GREEN", "Green"));
+	STR_DSI_YELLOW = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DSI_YELLOW", "Yellow"));
+	STR_DSI_PINK = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DSI_PINK", "Pink"));
+	STR_DSI_PURPLE = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DSI_PURPLE", "Purple"));
+	STR_R4_THEME01 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "R4_THEME01", "Snow hill"));
+	STR_R4_THEME02 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "R4_THEME02", "Snow land"));
+	STR_R4_THEME03 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "R4_THEME03", "Green leaf"));
+	STR_R4_THEME04 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "R4_THEME04", "Pink flower"));
+	STR_R4_THEME05 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "R4_THEME05", "Park"));
+	STR_R4_THEME06 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "R4_THEME06", "Cherry blossoms"));
+	STR_R4_THEME07 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "R4_THEME07", "Beach"));
+	STR_R4_THEME08 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "R4_THEME08", "Summer sky"));
+	STR_R4_THEME09 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "R4_THEME09", "River"));
+	STR_R4_THEME10 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "R4_THEME10", "Fall trees"));
+	STR_R4_THEME11 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "R4_THEME11", "Christmas tree"));
+	STR_R4_THEME12 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "R4_THEME12", "Drawn symbol"));
+	STR_R4_THEME13 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "R4_THEME13", "Blue moon"));
+	STR_R4_THEME14 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "R4_THEME14", "Mac-like"));
 
-	STR_DEFAULT_LAUNCHER = languageini.GetString("LANGUAGE", "DEFAULT_LAUNCHER", "Default launcher");
+	STR_DEFAULT_LAUNCHER = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DEFAULT_LAUNCHER", "Default launcher"));
 
-    STR_12_HOUR_CLOCK =  languageini.GetString("LANGUAGE", "12_HOUR_CLOCK", "Use a 12 hour clock");
-    STR_DESCRIPTION_12_HOUR_CLOCK = languageini.GetString("LANGUAGE", "DESCRIPTION_12_HOUR_CLOCK", "Use a 12-hour clock instead of a 24 hour clock in the Acekard theme.");
+    STR_12_HOUR_CLOCK =  ReplaceExtASCII(languageini.GetString("LANGUAGE", "12_HOUR_CLOCK", "Use a 12 hour clock"));
+    STR_DESCRIPTION_12_HOUR_CLOCK = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_12_HOUR_CLOCK", "Use a 12-hour clock instead of a 24 hour clock in the Acekard theme."));
 
-		STR_SNES_EMULATOR =  languageini.GetString("LANGUAGE", "SNES_EMULATOR", "Choose a SNES emulator");
-    STR_DESCRIPTION_SNES_EMULATOR = languageini.GetString("LANGUAGE", "DESCRIPTION_SNES_EMULATOR", "Choose whether you would rather use SNEmulDS or lolSNES.");
+		STR_SNES_EMULATOR =  ReplaceExtASCII(languageini.GetString("LANGUAGE", "SNES_EMULATOR", "Choose a SNES emulator"));
+    STR_DESCRIPTION_SNES_EMULATOR = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_SNES_EMULATOR", "Choose whether you would rather use SNEmulDS or lolSNES."));
 
-    STR_AK_ZOOMING_ICON = languageini.GetString("LANGUAGE", "AK_ZOOMING_ICON", "Zooming icons");
-    STR_DESCRIPTION_AK_ZOOMING_ICON = languageini.GetString("LANGUAGE", "DESCRIPTION_ZOOMING_ICON", "Display a zoom effect for the selected icon in the Acekard theme.");
+    STR_AK_ZOOMING_ICON = ReplaceExtASCII(languageini.GetString("LANGUAGE", "AK_ZOOMING_ICON", "Zooming icons"));
+    STR_DESCRIPTION_AK_ZOOMING_ICON = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_ZOOMING_ICON", "Display a zoom effect for the selected icon in the Acekard theme."));
 
-    STR_AK_SCROLLSPEED = languageini.GetString("LANGUAGE", "AK_SCROLLSPEED", "Scroll speed");
-    STR_DESCRIPTION_AK_SCROLLSPEED =  languageini.GetString("LANGUAGE", "DESCRIPTION_AK_SCROLLSPEED", "Sets the scroll speed in the Acekard theme.");
+    STR_AK_SCROLLSPEED = ReplaceExtASCII(languageini.GetString("LANGUAGE", "AK_SCROLLSPEED", "Scroll speed"));
+    STR_DESCRIPTION_AK_SCROLLSPEED =  ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_AK_SCROLLSPEED", "Sets the scroll speed in the Acekard theme."));
 
 	// The localestrign is here but the setting isn't displayed
 	// we can just keep the default viewmode
 	// which is icons with rom internal names.
 	// akmenu should save the view mode anyways when its changed with SELECT.
 	
-    STR_AK_VIEWMODE = languageini.GetString("LANGUAGE", "AK_VIEWMODE", "Default viewmode");
-    STR_DESCRIPTION_AK_VIEWMODE = languageini.GetString("LANGUAGE", "DESCRIPTION_AK_VIEWMODE", "Sets the default view mode in the Acekard theme.");
+    STR_AK_VIEWMODE = ReplaceExtASCII(languageini.GetString("LANGUAGE", "AK_VIEWMODE", "Default viewmode"));
+    STR_DESCRIPTION_AK_VIEWMODE = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_AK_VIEWMODE", "Sets the default view mode in the Acekard theme."));
 
-	STR_DESCRIPTION_DEFAULT_LAUNCHER_1 = languageini.GetString("LANGUAGE", "DESCRIPTION_DEFAULT_LAUNCHER_1_DSIMENUPP", "Launch Nintendo DSi Menu or TWiLight Menu++ on boot.");
+	STR_DESCRIPTION_DEFAULT_LAUNCHER_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_DEFAULT_LAUNCHER_1_DSIMENUPP", "Launch Nintendo DSi Menu or TWiLight Menu++ on boot."));
 }

--- a/settings/arm9/source/language.cpp
+++ b/settings/arm9/source/language.cpp
@@ -262,7 +262,7 @@ void langInit(void)
 
 	STR_DESCRIPTION_S1SDACCESS_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_S1SDACCESS_1", "Allows your flashcard to be used as a secondary device. Turn this off, if IR functionality doesn't work, or if the app crashes."));
 
-	STR_DESCRIPTION_MAINMENU = ReplaceExtASCII(languageini.GetString("LANGUAGE", "STR_DESCRIPTION_MAINMENU", "The menu that is shown before the ROM select menu. Has the look of the original DS UI."));
+	STR_DESCRIPTION_MAINMENU = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_MAINMENU", "The menu that is shown before the ROM select menu. Has the look of the original DS UI."));
 
 	STR_DESCRIPTION_THEME_1 = ReplaceExtASCII(languageini.GetString("LANGUAGE", "DESCRIPTION_THEME_1", "The theme to use in TWiLight Menu++. Press Left/Right to select, A for sub-themes."));
 

--- a/settings/nitrofiles/languages/italian.ini
+++ b/settings/nitrofiles/languages/italian.ini
@@ -3,17 +3,16 @@ SAVING_SETTINGS = Salvataggio delle impostazioni...
 SETTINGS_SAVED = Impostazioni salvate!
 
 LR_SWITCH = L/R/Y/X Cambia pagina
+MISC_SETTINGS = Impostazioni varie
 GUI_SETTINGS = Impostazioni GUI
 GAMESAPPS_SETTINGS = Impostazioni giochi e app
 
 ; GUI settings
 S1SDACCESS = Accesso microSD nello Slot-1
-MAINMENU = Menu principale
+MAINMENU = Main menu
 THEME = Tema
 LASTPLAYEDROM = Ultima ROM giocata all'avvio
 DSIMENUPPLOGO = Logo TWLMenu++ all'avvio
-SRLOADERLOGO = Logo SRLoader all'avvio
-DSISIONXLOGO = Logo DSiMenu++ all'avvio
 DIRECTORIES = Directory/Cartelle
 BOXART = Box art/Copertine giochi
 ANIMATEDSIICONS = Icone DSi animate
@@ -22,53 +21,49 @@ LAUNCHERAPP = Launcher SysNAND
 SYSTEMSETTINGS = Impostazioni di sistema
 REPLACEDSIMENU = Rimpiazza Menu DSi
 RESTOREDSIMENU = Ripristina Menu DSi
-DEFAULT_LAUNCHER = Launcher di default
 
 SHOW = Mostra
 HIDE = Nascondi
 
-DESCRIPTION_S1SDACCESS_1 = Consente di utilizzare la tua flashcard come dispositivo secondario. Disattivalo se la funzionalità IR non funziona o se l'app crasha.
+DESCRIPTION_S1SDACCESS_1 = Consente di utilizzare la tua flashcard come dispositivo secondario. Disattivalo se la funzionalit\xE0 IR non funziona o se l'app crasha.
 DESCRIPTION_MAINMENU = Il menu che viene mostrato prima del menu di selezione ROM. Ha lo stesso aspetto della UI del DS originale.
 
 DESCRIPTION_THEME_1 = Il tema da utilizzare in TWLMenu++. Premi Destra/Sinistra per scegliere, A per i sottotemi.
-DESCRIPTION_THEME_1_SRLOADER = Il tema da utilizzare in SRLoader. Premi Destra/Sinistra per scegliere, A per i sottotemi.
-DESCRIPTION_THEME_1_DSISIONX = Il tema da utilizzare in DSiMenu++. Premi Destra/Sinistra per scegliere, A per i sottotemi.
 
-DESCRIPTION_LASTPLAYEDROM_1 = Se attivato, tieni premuto B all'avvio per saltare il menù di selezione ROM.
+DESCRIPTION_LASTPLAYEDROM_1 = Se attivato, tieni premuto B all'avvio per saltare il men\xF9 di selezione ROM.
 
-DESCRIPTION_DSIMENUPPLOGO_1 = All'avvio verrà mostrato il logo di TWiLight Menu++.
-DESCRIPTION_SRLOADERLOGO_1 = All'avvio verrà mostrato il logo di SRLoader.
-DESCRIPTION_DSISIONXLOGO_1 = All'avvio verrà mostrato il logo di DSiMenu++.
+DESCRIPTION_DSIMENUPPLOGO_1 = All'avvio verr\xE0 mostrato il logo di TWiLight Menu++.
 
-DESCRIPTION_DIRECTORIES_1 = Se sei in una cartella dove sono presenti molti dei tuoi giochi, è sicuro nascondere le directory/cartelle.
+DESCRIPTION_DIRECTORIES_1 = Se sei in una cartella dove sono presenti molti dei tuoi giochi, \xE8 sicuro nascondere le directory/cartelle.
 
 DESCRIPTION_BOXART_1 = Mostrato nello schermo superiore del tema DSi/3DS.
 
 DESCRIPTION_ANIMATEDSIICONS_1 = Anima le icone DSi come nei Menu DSi e 3DS.
 
-DESCRIPTION_SYSREGION = Laregione della SysNAND. L'opzione "Auto" funzionerà solo se utilizzi l'SDNAND.
-DESCRIPTION_LAUNCHERAPP = Per ottenere il nome .app, premi il pulsante ACCENSIONE, tieni premuto A+B, poi evidenzia LAUNCHER.
+DESCRIPTION_SYSREGION = Laregione della SysNAND. L'opzione "Auto" funzioner\xE0 solo se utilizzi l'SDNAND.
+DESCRIPTION_LAUNCHERAPP = Per ottenere il nome .app, premi il pulsante POWER, tieni premuto A+B, poi evidenzia LAUNCHER.
 
 DESCRIPTION_SYSTEMSETTINGS_1 = Premi A per cambiare le impostazioni del tuo sistema Nintendo DSi.
 
 DESCRIPTION_REPLACEDSIMENU_1 = Avvia TWiLight Manu++ all'accensione, invece del Menu DSi.
-DESCRIPTION_REPLACEDSIMENU_1_SRLOADER = Avvia SRLoader all'accensione, invece del Menu DSi.
-DESCRIPTION_REPLACEDSIMENU_1_DSISIONX = Avvia DSiMenu++ all'accensione, invece del Menu DSi.
 
 DESCRIPTION_RESTOREDSIMENU_1 = Mostra il Menu DSi all'avvio.
 
 ; Games/Apps settings
 LANGUAGE = Lingua
-CPUSPEED = Velocità CPU ARM9
+CPUSPEED = Velocit\xE0 CPU ARM9
 VRAMBOOST = Boost VRAM
-SOUNDFIX = Fix suono
+USEBOOTSTRAP = Usa nds-bootstrap
 DEBUG = Debug
 LOGGING = Logging
 ROMREADLED = LED lettura ROM
 RUNIN = Avvia in
+SLOT1SCFGUNLOCK = Accesso SCFG da Slot-1
 SNDFREQ = Frequenza Altoparlanti/Mic
 SLOT1LAUNCHMETHOD = Metodo di avvio Slot-1
 LOADINGSCREEN = Schermata di caricamento
+LOADINGSCREENTHEME = Tema della schermata di caricamento
+LOADINGSCREENLOCATION = Posizione della schermata di caricamento
 BOOTSTRAP = Bootstrap
 USEGBARUNNER2 = Usa GBARunner2
 
@@ -83,18 +78,24 @@ CAMERA = Camera
 REBOOT = Riavvio
 DIRECT = Diretto
 REGULAR = Regolare
+DARK = Scura
+LIGHT = Chiara
+BOTTOM = In basso
+TOP = In alto
 RELEASE = Release
 NIGHTLY = Nightly
 
 DESCRIPTION_LANGUAGE_1 = Evita le selezioni limitate della lingua della tua console impostando questa opzione.
 
-DESCRIPTION_RUNIN_1 = Avvia in modalità DS o DSi.
+DESCRIPTION_RUNIN_1 = Avvia in modalit\xE0 DS o DSi.
 
 DESCRIPTION_CPUSPEED_1 = Imposta su TWL per liberarti del lag in alcuni giochi.
 
 DESCRIPTION_VRAMBOOST_1 = Permette scritture in VRAM ad 8 bit ed espande il bus a 32 bit.
 
-DESCRIPTION_SOUNDFIX_1 = Sistema la maggior parte degli scricchiolii nell'audio, doppi suoni e pause di frazioni di secondo.
+DESCRIPTION_SLOT1SCFGUNLOCK = Accesso a SCFG mentre si sta usando una flashcard Slot-1. Consende di impostare la modalit\xE0 di memoria estesa e/o la velocit\xE0 di clock negli homebrew della flashcard.
+
+DESCRIPTION_USEBOOTSTRAP = Viene utilizzato nds-bootstrap invece del kernel o firmware della flashcard.
 
 DESCRIPTION_DEBUG_1 = Mostra del testo prima di avviare il gioco.
 
@@ -102,30 +103,21 @@ DESCRIPTION_LOGGING_1 = Registra il processo di patch in sd:/NDSBTSRP.LOG
 
 DESCRIPTION_ROMREADLED_1 = Indica con un LED la lettura della ROM.
 
-DESCRIPTION_SNDFREQ_1 = 32.73 kHz Qualità originale, 47.61 kHz Alta qualità. Non rimarrà impostato con un soft reset o lanciando l'ultima ROM.
+DESCRIPTION_SNDFREQ_1 = 32.73 kHz Qualit\xE0 originale, 47.61 kHz Alta qualit\xE0. Non rimarr\xE0 impostato con un soft reset o lanciando l'ultima ROM.
 
-DESCRIPTION_SLOT1LAUNCHMETHOD_1 = Cambialo se alcune cartucce Slot-1 non si avviano. Inoltre il metodo riavvio non utlizzarà la lingua e la velocità della CPU impostate.
+DESCRIPTION_SLOT1LAUNCHMETHOD_1 = Cambialo se alcune cartucce Slot-1 non si avviano. Inoltre il metodo riavvio non utlizzer\xE0 la lingua e la velocit\xE0 della CPU impostate.
 
 DESCRIPTION_LOADINGSCREEN_1 = Mostra una schermata animata durante l'avvio della ROM con nds-bootstrap.
+
+DESCRIPTION_LOADINGSCREENTHEME = Scegli se utilizzare una schermata di caricamento chiara o scura.
+
+DESCRIPTION_LOADINGSCREENLOCATION = Mostra la schermata di caricamento o in alto o in basso.
 
 DESCRIPTION_BOOTSTRAP_1 = Scegli se usare bootstrap in versione release o nightly.
 
 DESCRIPTION_FLASHCARD_1 = Scegli una flashcard da usare per avviare le ROM.
 
-DESCRIPTION_GBARUNNER2_1 = Usa GBARunner2 o la modalità GBA nativa per avviare i giochi GBA.
-
-DESCRIPTION_DEFAULT_LAUNCHER_1_DSIMENUPP = Avvia il Menu DSi o TWiLight Menu++ alll'avvio.
-DESCRIPTION_DEFAULT_LAUNCHER_1_SRLOADER = Avvia il Menu DSi o SRLoader alll'avvio.
-DESCRIPTION_DEFAULT_LAUNCHER_1_DSISIONX = Avvia il Menu DSi o DSiMenu++ alll'avvio.
-
-12_HOUR_CLOCK =  Usa orologio a 12 ore
-DESCRIPTION_12_HOUR_CLOCK = Usa un orologio a 12 ore invece che 24 nel tema Acekard.
-
-AK_ZOOMING_ICON = Zooma icone
-DESCRIPTION_AK_ZOOMING_ICON = Mostra un effetto zoom per l'icona selezionata nel tema Acekard.
-
-AK_SCROLLSPEED = Velocità di scorrimento
-DESCRIPTION_AK_SCROLLSPEED = Imposta la velocità di scorrimento nel tema Acekard.
+DESCRIPTION_GBARUNNER2_1 = Usa GBARunner2 o la modalit\xE0 GBA nativa per avviare i giochi GBA.
 
 ; Flashcard(s) settings
 FLASHCARD_SELECT = Selezione Flashcard
@@ -134,11 +126,12 @@ AB_SETRETURN = A/B: Imposta e torna indietro
 
 ; Sub-theme select
 SUBTHEMESEL_DSI = Selezione sottotema: Menu DSi
-SUBTHEMESEL_3DS = Selezione sottotema: Menu HOME 3DS
+
 SUBTHEMESEL_R4 = Selezione sottotema: R4
+SUBTHEMESEL_AK = Selezione sottotema: Menu Acekard
 AB_SETSUBTHEME = A/B: Imposta sottotema
 DSI_DARKMENU = SD/Menu scuro
-DSI_NORMALMENU = Menu normale
+DSI_NORMALMENU = Normale/Menu chiaro
 DSI_RED = Rosso
 DSI_BLUE = Blu
 DSI_GREEN = Verde
@@ -159,3 +152,19 @@ R4_THEME11 = Albero di natale
 R4_THEME12 = Simbolo
 R4_THEME13 = Luna blu
 R4_THEME14 = Simil-Mac
+
+DEFAULT_LAUNCHER = Launcher di default
+
+12_HOUR_CLOCK =  Usa orologio a 12 ore
+DESCRIPTION_12_HOUR_CLOCK = Usa un orologio a 12 ore invece che 24 nel tema Acekard.
+
+SNES_EMULATOR =  Selezione emulatore SNES
+DESCRIPTION_SNES_EMULATOR = Scegli se utilizzare SNEmulDS o lolSNES.
+
+AK_ZOOMING_ICON = Zooma icone
+DESCRIPTION_AK_ZOOMING_ICON = Mostra un effetto zoom per l'icona selezionata nel tema Acekard.
+
+AK_SCROLLSPEED = Velocit\xE0 di scorrimento
+DESCRIPTION_AK_SCROLLSPEED = Imposta la velocit\xE0 di scorrimento nel tema Acekard.
+
+DESCRIPTION_DEFAULT_LAUNCHER_1_DSIMENUPP = Avvia il Menu DSi o TWiLight Menu++ alll'avvio.


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Added additional function when parsing language strings that allows the app to read characters in the form "\xHH", to avoid the various encoding issues that are happening with characters that are part of the extended ascii charset. There's also an updated italian.ini file with strings using this "encoding" for accented characters.

#### Where have you tested it?

Tested on no$gba

*** 
#### Pull Request status
- [ ]  This PR has been tested using latest devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
