### PR TITLE
Fixed typo in ReplaceExtASCII

### DIFF
--- a/settings/arm9/source/language.cpp
+++ b/settings/arm9/source/language.cpp
@@ -194,7 +194,7 @@ std::string ReplaceExtASCII(const std::string& input) {
 	std::string res;
 	for(size_t i = 0; i < input.size(); i++) {
 		if(i < input.size() - 3 && (i == 0 || input[i - 1] != '\\') && input[i] == '\\' && (input[i + 1] == 'x' || input[i + 1] == 'X')) {
-			int c = std::stoi(input.substr(i + 2, i + 2), 0, 16);
+			int c = std::stoi(input.substr(i + 2, 2), 0, 16);
 			res += (char)c;
 			i += 3;
 		} else


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

I wrongly added "i +" in the length of the substr, it could have caused issues in the case the next character was a valid hexadecimal digit.

#### Where have you tested it?

_Tell us where have you tested it._

*** 
#### Pull Request status
- [ ]  This PR has been tested using latest devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
