### PR TITLE
Fixed backwards option scrolling

### DIFF
--- a/settings/arm9/source/settingsgui.cpp
+++ b/settings/arm9/source/settingsgui.cpp
@@ -233,7 +233,7 @@ void SettingsGUI::rotateOptionValue(int rotateAmount)
 
     auto selectedOption = _pages[_selectedPage].options()[_selectedOption];
     int currentValueIndex = selectedOption.selected();
-    int nextValueIndex = (currentValueIndex + rotateAmount) % (selectedOption.values().size());
+    int nextValueIndex = (currentValueIndex + rotateAmount + selectedOption.values().size()) % (selectedOption.values().size());
     if (currentValueIndex == -1)
         nextValueIndex = 0;
     auto nextValue = selectedOption.values()[nextValueIndex];


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Fixed an issue where if you scrolled an option backwards, like the languages option, when going from option 0, the result of the modulus wasn't the latest option but -1. With this change, the size of the option list is added so that the result of the modulus is the same, and it doesn't have to deal with negative values.

#### Where have you tested it?

No$gba

*** 
#### Pull Request status
- [x]  This PR has been tested using latest devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
