### PR TITLE
Fixed Guru Error when misc setting page if set language to 6 in settings.ini

### DIFF
--- a/settings/arm9/source/language.cpp
+++ b/settings/arm9/source/language.cpp
@@ -266,6 +266,9 @@ void langInit(void)
 	case 5:
 		languageIniPath = "nitro:/languages/spanish.ini";
 		break;
+	case 6:
+		languageIniPath = "nitro:/languages/english.ini";
+		break;
 	}
 
 	CIniFile languageini(languageIniPath);

--- a/settings/arm9/source/main.cpp
+++ b/settings/arm9/source/main.cpp
@@ -569,14 +569,16 @@ SettingsPage miscPage(STR_MISC_SETTINGS);
 				 "French",
 				 "German",
 				 "Italian",
-				 "Spanish"},
+				 "Spanish",
+				 "Chinese"},
 				{TLanguage::ELangDefault,
 				 TLanguage::ELangJapanese,
 				 TLanguage::ELangEnglish,
 				 TLanguage::ELangFrench,
 				 TLanguage::ELangGerman,
 				 TLanguage::ELangItalian,
-				 TLanguage::ELangSpanish})
+				 TLanguage::ELangSpanish,
+				 TLanguage::ELangChinese})
 		.option(STR_COLORMODE,
 				STR_DESCRIPTION_COLORMODE,
 				Option::Int(&ms().colorMode),


### PR DESCRIPTION
This PR has been tested using the provided devkitPro, devkitARM and tested on DSi console.
The chinese.ini Not yet created and translated!Because there is no Chinese characters fonts support