### PR TITLE
Clean the select Menu icons when gbar2 bios error

### DIFF
--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -669,6 +669,7 @@ void launchGba(void) {
 		mmEffectEx(&snd_wrong);
 		clearText();
 		dbox_showIcon = false;
+		dbox_selectMenu = false;
 		if (!showdialogbox) {
 			showdialogbox = true;
 			for (int i = 0; i < 30; i++) swiWaitForVBlank();
@@ -691,6 +692,7 @@ void launchGba(void) {
 			swiWaitForVBlank();
 		} while (!(pressed & KEY_A));
 		clearText();
+		dbox_selectMenu = true;
 		if (!inSelectMenu) {
 			showdialogbox = false;
 			for (int i = 0; i < 15; i++) swiWaitForVBlank();


### PR DESCRIPTION
Tested on DSi console