### PR TITLE
DSi Theme: Reduce scroll lag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ title:
 	@$(MAKE) -C title
 
 clean:
-	@echo clean build direcotiries
+	@echo clean build directories
 	@$(MAKE) -C booter clean
 	@$(MAKE) -C booter_fc clean
 	@$(MAKE) -C mainmenu clean

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -251,6 +251,8 @@ extern bool usernameRenderedDone;
 const char *gameOrderIniPath;
 const char *hiddenGamesIniPath;
 
+static bool inSelectMenu = false;
+
 struct DirEntry
 {
 	string name;
@@ -509,7 +511,41 @@ void updateScrollingState(u32 held, u32 pressed) {
 
 }
 
-static bool inSelectMenu = false;
+void updateBoxArt(vector<DirEntry> dirContents[], SwitchState scrn) {
+
+	if (cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40 > ((int) dirContents[scrn].size() - 1)) {
+		if (!boxArtLoaded && showBoxArt) {
+			if (!rocketVideo_playVideo) clearBoxArt();	// Clear box art
+			if (theme == 1) rocketVideo_playVideo = true;
+			boxArtLoaded = true;
+		}
+		showbubble = false;
+		showSTARTborder = (theme == 1 ? true : false);
+		clearText(false);	// Clear title
+	} else {
+
+		if (!boxArtLoaded && showBoxArt) {
+			if (isDirectory[cursorPosition[secondaryDevice]]) {
+				if (theme == 1) {
+					if (!rocketVideo_playVideo) {
+						clearBoxArt();	// Clear box art, if it's a directory
+						rocketVideo_playVideo = true;
+					}
+				} else {
+					clearBoxArt();	// Clear box art, if it's a directory
+				}
+			} else {
+				rocketVideo_playVideo = false;
+				if (theme == 1) clearBoxArt();	// Clear top screen cubes or box art
+				loadBoxArt(boxArtPath[cursorPosition[secondaryDevice]]);	// Load box art
+			}
+			boxArtLoaded = true;
+		}
+		showbubble = true;
+		showSTARTborder = true;
+		titleUpdate(dirContents[scrn].at(cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40).isDirectory, dirContents[scrn].at(cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40).name.c_str(), cursorPosition[secondaryDevice]);
+	}
+}
 
 void launchSettings(void) {
 	mmEffectEx(&snd_launch);
@@ -1146,38 +1182,6 @@ string browseForFile(const vector<string> extensionList, const char* username)
 			// cursor->finalY = 4 + 10 * (cursorPosition[secondaryDevice] - screenOffset + ENTRIES_START_ROW);
 			// cursor->delay = TextEntry::ACTIVE;
 
-			if (cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40 > ((int) dirContents[scrn].size() - 1)) {
-				if (!boxArtLoaded && showBoxArt) {
-					if (!rocketVideo_playVideo) clearBoxArt();	// Clear box art
-					if (theme == 1) rocketVideo_playVideo = true;
-					boxArtLoaded = true;
-				}
-				showbubble = false;
-				showSTARTborder = (theme == 1 ? true : false);
-				clearText(false);	// Clear title
-			} else {
-				if (!boxArtLoaded && showBoxArt) {
-					if (isDirectory[cursorPosition[secondaryDevice]]) {
-						if (theme == 1) {
-							if (!rocketVideo_playVideo) {
-								clearBoxArt();	// Clear box art, if it's a directory
-								rocketVideo_playVideo = true;
-							}
-						} else {
-							clearBoxArt();	// Clear box art, if it's a directory
-						}
-					} else {
-						rocketVideo_playVideo = false;
-						if (theme == 1) clearBoxArt();	// Clear top screen cubes or box art
-						loadBoxArt(boxArtPath[cursorPosition[secondaryDevice]]);	// Load box art
-					}
-					boxArtLoaded = true;
-				}
-				showbubble = true;
-				showSTARTborder = true;
-				titleUpdate(dirContents[scrn].at(cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40).isDirectory, dirContents[scrn].at(cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40).name.c_str(), cursorPosition[secondaryDevice]);
-			}
-
 			if (!stopSoundPlayed) {
 				if ((theme == 0 && !startMenu && cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40 <= ((int) dirContents[scrn].size() - 1))
 				|| (theme == 0 && startMenu && startMenu_cursorPosition < (3-flashcardFound()))) {
@@ -1212,6 +1216,7 @@ string browseForFile(const vector<string> extensionList, const char* username)
 				if (!isScrolling) {
 					buttonArrowTouched[0] = false;
 					buttonArrowTouched[1] = false;
+					updateBoxArt(dirContents, scrn);
 				}
 				loadVolumeImage();
 				loadBatteryImage();
@@ -1223,6 +1228,7 @@ string browseForFile(const vector<string> extensionList, const char* username)
 					break;
 				}*/
 			}
+
 			while (!pressed && !held);
 			if (((pressed & KEY_LEFT) && !titleboxXmoveleft && !titleboxXmoveright)
 			|| ((held & KEY_LEFT) && !titleboxXmoveleft && !titleboxXmoveright)

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -512,7 +512,6 @@ void updateScrollingState(u32 held, u32 pressed) {
 }
 
 void updateBoxArt(vector<DirEntry> dirContents[], SwitchState scrn) {
-
 	if (cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40 > ((int) dirContents[scrn].size() - 1)) {
 		if (!boxArtLoaded && showBoxArt) {
 			if (!rocketVideo_playVideo) clearBoxArt();	// Clear box art
@@ -523,7 +522,6 @@ void updateBoxArt(vector<DirEntry> dirContents[], SwitchState scrn) {
 		showSTARTborder = (theme == 1 ? true : false);
 		clearText(false);	// Clear title
 	} else {
-
 		if (!boxArtLoaded && showBoxArt) {
 			if (isDirectory[cursorPosition[secondaryDevice]]) {
 				if (theme == 1) {
@@ -543,7 +541,6 @@ void updateBoxArt(vector<DirEntry> dirContents[], SwitchState scrn) {
 		}
 		showbubble = true;
 		showSTARTborder = true;
-		titleUpdate(dirContents[scrn].at(cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40).isDirectory, dirContents[scrn].at(cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40).name.c_str(), cursorPosition[secondaryDevice]);
 	}
 }
 
@@ -1218,6 +1215,8 @@ string browseForFile(const vector<string> extensionList, const char* username)
 					buttonArrowTouched[1] = false;
 					updateBoxArt(dirContents, scrn);
 				}
+				if (cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40 < ((int) dirContents[scrn].size()))
+					titleUpdate(dirContents[scrn].at(cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40).isDirectory, dirContents[scrn].at(cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40).name.c_str(), cursorPosition[secondaryDevice]);
 				loadVolumeImage();
 				loadBatteryImage();
 				loadTime();

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -1214,6 +1214,9 @@ string browseForFile(const vector<string> extensionList, const char* username)
 					buttonArrowTouched[0] = false;
 					buttonArrowTouched[1] = false;
 					updateBoxArt(dirContents, scrn);
+				} else {
+					if (boxArtLoaded)
+						clearBoxArt();
 				}
 				if (cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40 < ((int) dirContents[scrn].size()))
 					titleUpdate(dirContents[scrn].at(cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40).isDirectory, dirContents[scrn].at(cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40).name.c_str(), cursorPosition[secondaryDevice]);


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?
In the DSi theme, now when you are scrolling, box art is not displayed
The start border is not drawn while you are scrolling
As a result, lag when scrolling has been reduced

Small typo in the Makefile has been fixed
#### Where have you tested it?
Old 2DS
*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
