### PR TITLE
Assign photoPath only if dirOpen is true

### DIFF
--- a/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
@@ -1399,9 +1399,8 @@ void loadPhotoList()
 			photoList.emplace_back(dirPath+photoDir);
 		}
 		closedir(dir);
+		photoPath = photoList[rand()/((RAND_MAX+1u)/photoList.size())];
 	}
-
-	photoPath = photoList[rand()/((RAND_MAX+1u)/photoList.size())];
 }
 
 void loadPhoto() {
@@ -1948,6 +1947,7 @@ void graphicsInit()
 		if (theme == 1) titleboxYposDropDown[i] = 0;
 		else titleboxYposDropDown[i] = -85-80;
 	}
+
 	allowedTitleboxForDropDown = 0;
 	delayForTitleboxToDropDown = 0;
 	dropDown = false;
@@ -2055,12 +2055,12 @@ void graphicsInit()
 	REG_BG3PC_SUB = 0;
 	REG_BG3PD_SUB = 1<<8;
 
-
 	if (theme < 1) {
 		srand(time(NULL));
 		loadPhotoList();
 		loadPhoto();
 	}
+
 
 	REG_BLDCNT = BLEND_SRC_BG3 | BLEND_FADE_BLACK;
 	


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?
`photoPath` now only gets assigned if `dirOpen` is set to true. This prevents a bug on flashcarts (at least on my R4) where the DSi menu theme crashes and the DS is powered off.
#### Where have you tested it?
DS Lite (r4)
Old 2DS (r4 & SD)
*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
