### PR TITLE
dsimenu: Reload the corner button palettes on the 3ds theme

### DIFF
--- a/romsel_dsimenutheme/arm9/source/graphics/ThemeTextures.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/ThemeTextures.cpp
@@ -232,7 +232,18 @@ void ThemeTextures::reloadPalDialogBox()
   extern int theme;
   glBindTexture(0, dialogboxTexID);
   glColorSubTableEXT(0, 0, 12, 0, 0, (u16 *)(theme==1 ? dialogboxPal : apply_personal_theme(button_arrowPals)));
+  if (theme != 1) {
+    glBindTexture(0, cornerButtonTexID);
+    glColorSubTableEXT(0, 0, 16, 0, 0, (u16 *)(cornerbuttonPal));
+  }
 }
+
+void ThemeTextures::reloadPal3dsCornerButton()
+{
+  glBindTexture(0, cornerButtonTexID);
+  glColorSubTableEXT(0, 0, 16, 0, 0, (u16 *)(_3ds_cornerbuttonPal));
+}
+
 void ThemeTextures::drawBg()
 {
   DC_FlushRange(loadedBottomImg, 0x18000);

--- a/romsel_dsimenutheme/arm9/source/graphics/ThemeTextures.h
+++ b/romsel_dsimenutheme/arm9/source/graphics/ThemeTextures.h
@@ -48,6 +48,7 @@ public:
   void load3DSTheme();
 
   void reloadPalDialogBox();
+  void reloadPal3dsCornerButton();
 
 private:
   void loadBubbleImage(const unsigned short *palette, const unsigned int *bitmap, int sprW, int sprH, int texW);

--- a/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
@@ -970,6 +970,10 @@ void vBlankHandler()
 					// Reload the dialog box palettes here...
 					reloadDboxPalette();
 				} else if (!showdialogbox) {
+					if (theme == 1) {
+						// on other themes, reloadDboxPalettes also reloads cornerbutton palettes
+						tex().reloadPal3dsCornerButton();
+					}
 					reloadIconPalettes();
 					reloadFontPalettes();
 				}


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

The corner button palettes on the 3DS theme become corrupt sometimes, especially when changing icon positions. This just reloads the palettes once in a while to stop the corruption.

#### Where have you tested it?

Nintendo DSi hardware.

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
