### PR TITLE
Scroll fixes

### DIFF
--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -1204,7 +1204,7 @@ string browseForFile(const vector<string> extensionList, const char* username)
 				updateScrollingState(held, pressed);
 				if (isScrolling) {
 					if (boxArtLoaded) {
-						clearBoxArt();
+						if (!rocketVideo_playVideo) clearBoxArt();
 						rocketVideo_playVideo = (theme == 1 ? true : false);
 					}
 				} else {
@@ -1216,7 +1216,7 @@ string browseForFile(const vector<string> extensionList, const char* username)
 					showbubble = true, showBoxArt = true;
 					titleUpdate(dirContents[scrn].at(cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40).isDirectory, dirContents[scrn].at(cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40).name.c_str(), cursorPosition[secondaryDevice]);
 				} else {
-					if (showBoxArt) {
+					if (showBoxArt && !rocketVideo_playVideo) {
 						clearBoxArt();
 						showBoxArt = false;
 					}

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -1202,23 +1202,27 @@ string browseForFile(const vector<string> extensionList, const char* username)
 				held = keysDownRepeat();
 				touchRead(&touch);
 				updateScrollingState(held, pressed);
-				if (!isScrolling) {
+				if (isScrolling) {
+					if (boxArtLoaded) {
+						clearBoxArt();
+						rocketVideo_playVideo = (theme == 1 ? true : false);
+					}
+				} else {
 					buttonArrowTouched[0] = false;
 					buttonArrowTouched[1] = false;
 					updateBoxArt(dirContents, scrn);
-				} else {
-					if (boxArtLoaded) {
-						clearBoxArt();
-						if (theme == 1) rocketVideo_playVideo = true;
-					}
 				}
 				if (cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40 < ((int) dirContents[scrn].size())) {
-					showbubble = true;
+					showbubble = true, showBoxArt = true;
 					titleUpdate(dirContents[scrn].at(cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40).isDirectory, dirContents[scrn].at(cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40).name.c_str(), cursorPosition[secondaryDevice]);
 				} else {
+					if (showBoxArt) {
+						clearBoxArt();
+						showBoxArt = false;
+					}
 					clearText(false);
 					showbubble = false;
-					showSTARTborder = (theme == 1 ? true : false);
+					showSTARTborder = rocketVideo_playVideo = (theme == 1 ? true : false);
 				}
 				loadVolumeImage();
 				loadBatteryImage();


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?
Prevent boxart from staying after pressing to scroll past the last game.
If scrolling from a folder in the 3ds theme to nothing, do not call `clearBoxArt()`. Prevents flickering.
#### Where have you tested it?
Old 2DS (DSi/3DS themes, with directories on/off)
*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
