### PR TITLE
akmenu: Only call select handler once on list click (fixes #415)

### DIFF
--- a/romsel_aktheme/arm9/source/windows/mainwnd.cpp
+++ b/romsel_aktheme/arm9/source/windows/mainwnd.cpp
@@ -95,10 +95,13 @@ void MainWnd::init()
     _mainList->init();
     _mainList->selectChanged.connect(this, &MainWnd::listSelChange);
     _mainList->selectedRowClicked.connect(this, &MainWnd::onMainListSelItemClicked);
-    _mainList->selectedRowHeadClicked.connect(this, &MainWnd::onMainListSelItemHeadClicked);
     _mainList->directoryChanged.connect(this, &MainWnd::onFolderChanged);
     _mainList->animateIcons.connect(this, &MainWnd::onAnimation);
 
+
+    // This is commented out to prevent a double call of the list select handler when the head (file icon) is clicked.
+    // _mainList->selectedRowHeadClicked.connect(this, &MainWnd::onMainListSelItemHeadClicked);
+ 
     addChildWindow(_mainList);
     dbg_printf("mainlist %08x\n", _mainList);
 
@@ -452,11 +455,6 @@ void MainWnd::onKeyYPressed()
 }
 
 void MainWnd::onMainListSelItemClicked(u32 index)
-{
-    onKeyAPressed();
-}
-
-void MainWnd::onMainListSelItemHeadClicked(u32 index)
 {
     onKeyAPressed();
 }

--- a/romsel_aktheme/arm9/source/windows/mainwnd.h
+++ b/romsel_aktheme/arm9/source/windows/mainwnd.h
@@ -56,8 +56,6 @@ class MainWnd : public akui::Form
   protected:
     void onMainListSelItemClicked(u32 index);
 
-    void onMainListSelItemHeadClicked(u32 index);
-
     void onKeyAPressed();
 
     void onKeyBPressed();


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

The select handler for the akmenu list view would be called twice if someone clicks the icon, causing a Guru meditation in some cases, and going down two folders in others. This is makes it so it's only called once.

#### Where have you tested it?

Nintendo DSi hardware

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
