### PR TITLE
Fix DSi start border showing for a split second without the use of a delay

### DIFF
--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -1215,7 +1215,6 @@ string browseForFile(const vector<string> extensionList, const char* username)
 				touchRead(&touch);
 				updateScrollingState(held, pressed);
 			
-
 				if (isScrolling) {
 					if (boxArtLoaded) {
 						if (!rocketVideo_playVideo) clearBoxArt();
@@ -1247,10 +1246,7 @@ string browseForFile(const vector<string> extensionList, const char* username)
 				/*if (REG_SCFG_MC != current_SCFG_MC) {
 					break;
 				}*/
-			}
-
-			while (!pressed && !held);
-
+			} while (!pressed && !held);
 
 			if (((pressed & KEY_LEFT) && !titleboxXmoveleft && !titleboxXmoveright)
 			|| ((held & KEY_LEFT) && !titleboxXmoveleft && !titleboxXmoveright)
@@ -1354,8 +1350,9 @@ string browseForFile(const vector<string> extensionList, const char* username)
 								iconUpdate(dirContents[scrn].at((cursorPosition[secondaryDevice]-2)+pagenum[secondaryDevice]*40).isDirectory, dirContents[scrn].at((cursorPosition[secondaryDevice]-2)+pagenum[secondaryDevice]*40).name.c_str(), cursorPosition[secondaryDevice]-2);
 								defer(reloadFontTextures);
 							}
-						} else {
+						} else if (!edgeBumpSoundPlayed){
 							mmEffectEx(&snd_wrong);
+							edgeBumpSoundPlayed = true;
 						}
 					}
 					else if((pressed & KEY_RIGHT && !titleboxXmoveleft && !titleboxXmoveright)
@@ -1369,8 +1366,9 @@ string browseForFile(const vector<string> extensionList, const char* username)
 								iconUpdate(dirContents[scrn].at((cursorPosition[secondaryDevice]+2)+pagenum[secondaryDevice]*40).isDirectory, dirContents[scrn].at((cursorPosition[secondaryDevice]+2)+pagenum[secondaryDevice]*40).name.c_str(), cursorPosition[secondaryDevice]+2);
 								defer(reloadFontTextures);
 							}
-						} else {
+						} else  if (!edgeBumpSoundPlayed){
 							mmEffectEx(&snd_wrong);
+							edgeBumpSoundPlayed = true;
 						}
 					} else if(pressed & KEY_DOWN) {
 						for(int i=0;i<10;i++) {

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -515,7 +515,7 @@ int waitBeforeShowingSTARTborder = 30;
 
 void updateBoxArt(vector<DirEntry> dirContents[], SwitchState scrn) {
 	if (cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40 < ((int) dirContents[scrn].size())) {
-		if (!boxArtLoaded && showBoxArt) {
+		if (!boxArtLoaded && showBoxArt && waitBeforeShowingSTARTborder == 15) {
 			if (isDirectory[cursorPosition[secondaryDevice]]) {
 				if (theme == 1) {
 					if (!rocketVideo_playVideo) {

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -511,11 +511,9 @@ void updateScrollingState(u32 held, u32 pressed) {
 
 }
 
-int waitBeforeShowingSTARTborder = 30;
-
 void updateBoxArt(vector<DirEntry> dirContents[], SwitchState scrn) {
 	if (cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40 < ((int) dirContents[scrn].size())) {
-		if (!boxArtLoaded && showBoxArt && waitBeforeShowingSTARTborder == 15) {
+		if (!boxArtLoaded && showBoxArt) {
 			if (isDirectory[cursorPosition[secondaryDevice]]) {
 				if (theme == 1) {
 					if (!rocketVideo_playVideo) {
@@ -532,12 +530,7 @@ void updateBoxArt(vector<DirEntry> dirContents[], SwitchState scrn) {
 			}
 			boxArtLoaded = true;
 		}
-		if (waitBeforeShowingSTARTborder == 30) {
-			showSTARTborder = true;
-			waitBeforeShowingSTARTborder = 0;
-		} else {
-			waitBeforeShowingSTARTborder++;
-		}
+		showSTARTborder = true;
 	}
 }
 
@@ -662,7 +655,6 @@ void switchDevice(void) {
 		shouldersRendered = false;
 		showbubble = false;
 		showSTARTborder = false;
-		waitBeforeShowingSTARTborder = 30;
 		stopSoundPlayed = false;
 		clearText();
 		SaveSettings();
@@ -1217,7 +1209,6 @@ string browseForFile(const vector<string> extensionList, const char* username)
 						if (!rocketVideo_playVideo) clearBoxArt();
 						rocketVideo_playVideo = (theme == 1 ? true : false);
 					}
-					showSTARTborder = (theme == 1 ? true : false);
 				} else {
 					buttonArrowTouched[0] = false;
 					buttonArrowTouched[1] = false;
@@ -1233,7 +1224,6 @@ string browseForFile(const vector<string> extensionList, const char* username)
 					}
 					clearText(false);
 					showbubble = false;
-					waitBeforeShowingSTARTborder = 30;
 					showSTARTborder = rocketVideo_playVideo = (theme == 1 ? true : false);
 				}
 				loadVolumeImage();
@@ -1295,7 +1285,6 @@ string browseForFile(const vector<string> extensionList, const char* username)
 			&& cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40 < ((int) dirContents[scrn].size()))
 			{
 				showSTARTborder = false;
-				waitBeforeShowingSTARTborder = 30;
 				showbubble = false;
 				clearText();
 				mkdir (sdFound() ? "sd:/_nds/TWiLightMenu/extras" : "fat:/_nds/TWiLightMenu/extras", 0777);
@@ -1510,7 +1499,6 @@ string browseForFile(const vector<string> extensionList, const char* username)
 				touchPosition startTouch = touch;
 				int prevPos = cursorPosition[secondaryDevice];
 				showSTARTborder = false;
-				waitBeforeShowingSTARTborder = 30;
 				scrollWindowTouched = true;
 				while(1) {
 					scanKeys();
@@ -1620,7 +1608,6 @@ string browseForFile(const vector<string> extensionList, const char* username)
 				touchPosition prevTouch2 = touch;
 				int prevPos = cursorPosition[secondaryDevice];
 				showSTARTborder = false;
-				waitBeforeShowingSTARTborder = 30;
 
 				if(touch.px > 96 && touch.px < 160 && touch.py < 144 && touch.py > 88) {
 					while(1) {
@@ -1787,7 +1774,6 @@ string browseForFile(const vector<string> extensionList, const char* username)
 				touch = startTouch;
 				if(cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40 < ((int) dirContents[scrn].size()))
 					showSTARTborder = (theme == 1 ? true : false);
-				waitBeforeShowingSTARTborder = 30;
 			}
 
 			if (cursorPosition[secondaryDevice] < 0)
@@ -1818,7 +1804,6 @@ string browseForFile(const vector<string> extensionList, const char* username)
 					shouldersRendered = false;
 					showbubble = false;
 					showSTARTborder = false;
-					waitBeforeShowingSTARTborder = 30;
 					stopSoundPlayed = false;
 					clearText();
 					chdir(entry->name.c_str());
@@ -1936,7 +1921,6 @@ string browseForFile(const vector<string> extensionList, const char* username)
 					if (theme == 0) {
 						showbubble = false;
 						showSTARTborder = false;
-						waitBeforeShowingSTARTborder = 30;
 						clearText(false);	// Clear title
 
 						fadeSpeed = false;	// Slow fade speed
@@ -2037,7 +2021,6 @@ string browseForFile(const vector<string> extensionList, const char* username)
 					shouldersRendered = false;
 					showbubble = false;
 					showSTARTborder = false;
-					waitBeforeShowingSTARTborder = 30;
 					stopSoundPlayed = false;
 					clearText();
 					SaveSettings();
@@ -2071,7 +2054,6 @@ string browseForFile(const vector<string> extensionList, const char* username)
 					shouldersRendered = false;
 					showbubble = false;
 					showSTARTborder = false;
-					waitBeforeShowingSTARTborder = 30;
 					stopSoundPlayed = false;
 					clearText();
 					SaveSettings();
@@ -2098,7 +2080,6 @@ string browseForFile(const vector<string> extensionList, const char* username)
 				shouldersRendered = false;
 				showbubble = false;
 				showSTARTborder = false;
-				waitBeforeShowingSTARTborder = 30;
 				stopSoundPlayed = false;
 				clearText();
 				chdir("..");
@@ -2190,7 +2171,6 @@ string browseForFile(const vector<string> extensionList, const char* username)
 						shouldersRendered = false;
 						showbubble = false;
 						showSTARTborder = false;
-						waitBeforeShowingSTARTborder = 30;
 						stopSoundPlayed = false;
 						clearText();
 						showdialogbox = false;
@@ -2227,7 +2207,6 @@ string browseForFile(const vector<string> extensionList, const char* username)
 						shouldersRendered = false;
 						showbubble = false;
 						showSTARTborder = false;
-						waitBeforeShowingSTARTborder = 30;
 						stopSoundPlayed = false;
 						clearText();
 						showdialogbox = false;

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -150,6 +150,7 @@ bool shouldersRendered = false;
 bool settingsChanged = false;
 
 bool isScrolling = false;
+bool edgeBumpSoundPlayed = false;
 bool needToPlayStopSound = false;
 bool stopSoundPlayed = false;
 int waitForNeedToPlayStopSound = 0;
@@ -503,12 +504,21 @@ void updateScrollingState(u32 held, u32 pressed) {
 	 if (isHeld && !isPressed 
 	 	&&(
 			(cursorPosition[secondaryDevice] != 0 && cursorPosition[secondaryDevice] != 39) 
-		)){
+		))
+	{
 		isScrolling = true;
+		if (edgeBumpSoundPlayed) {
+			edgeBumpSoundPlayed = false;
+		}
 	} else if (!isHeld && !isPressed && !titleboxXmoveleft && !titleboxXmoveright) {
 		isScrolling = false;
 	} 
 
+	if (isPressed && !isHeld) {
+		if (edgeBumpSoundPlayed) {
+			edgeBumpSoundPlayed = false;
+		}
+	}
 }
 
 void updateBoxArt(vector<DirEntry> dirContents[], SwitchState scrn) {
@@ -1154,7 +1164,6 @@ string browseForFile(const vector<string> extensionList, const char* username)
 		clearText(false);
 		waitForFadeOut();
 		bool gameTapped = false;
-
 		/* clearText(false);
 		updatePath();
 		TextPane *pane = &createTextPane(20, 3 + ENTRIES_START_ROW*FONT_SY, ENTRIES_PER_SCREEN);
@@ -1167,6 +1176,7 @@ string browseForFile(const vector<string> extensionList, const char* username)
 		TextEntry *cursor = getPreviousTextEntry(false);
 		cursor->fade = TextEntry::FadeType::IN;
 		cursor->finalX += 16; */
+		
 
 		while (1)
 		{
@@ -1204,6 +1214,8 @@ string browseForFile(const vector<string> extensionList, const char* username)
 				held = keysDownRepeat();
 				touchRead(&touch);
 				updateScrollingState(held, pressed);
+			
+
 				if (isScrolling) {
 					if (boxArtLoaded) {
 						if (!rocketVideo_playVideo) clearBoxArt();
@@ -1238,6 +1250,8 @@ string browseForFile(const vector<string> extensionList, const char* username)
 			}
 
 			while (!pressed && !held);
+
+
 			if (((pressed & KEY_LEFT) && !titleboxXmoveleft && !titleboxXmoveright)
 			|| ((held & KEY_LEFT) && !titleboxXmoveleft && !titleboxXmoveright)
 			|| ((pressed & KEY_TOUCH) && touch.py > 171 && touch.px < 19 && theme == 0 && !titleboxXmoveleft && !titleboxXmoveright))		// Button arrow (DSi theme)
@@ -1250,8 +1264,10 @@ string browseForFile(const vector<string> extensionList, const char* username)
 					mmEffectEx(&snd_select);
 					boxArtLoaded = false;
 					settingsChanged = true;
-				} else {
+				} 
+				else if (!edgeBumpSoundPlayed) {
 					mmEffectEx(&snd_wrong);
+					edgeBumpSoundPlayed = true;
 				}
 				if(cursorPosition[secondaryDevice] >= 2 && cursorPosition[secondaryDevice] <= 36) {
 					if (bnrRomType[cursorPosition[secondaryDevice]-2] == 0 && (cursorPosition[secondaryDevice]-2)+pagenum[secondaryDevice]*40 < file_count) {
@@ -1271,9 +1287,12 @@ string browseForFile(const vector<string> extensionList, const char* username)
 					mmEffectEx(&snd_select);
 					boxArtLoaded = false;
 					settingsChanged = true;
-				} else {
+				} 
+				else if (!edgeBumpSoundPlayed){
 					mmEffectEx(&snd_wrong);
+					edgeBumpSoundPlayed = true;
 				}
+		
 				if(cursorPosition[secondaryDevice] >= 3 && cursorPosition[secondaryDevice] <= 37) {
 					if (bnrRomType[cursorPosition[secondaryDevice]+2] == 0 && (cursorPosition[secondaryDevice]+2)+pagenum[secondaryDevice]*40 < file_count) {
 						iconUpdate(dirContents[scrn].at((cursorPosition[secondaryDevice]+2)+pagenum[secondaryDevice]*40).isDirectory, dirContents[scrn].at((cursorPosition[secondaryDevice]+2)+pagenum[secondaryDevice]*40).name.c_str(), cursorPosition[secondaryDevice]+2);

--- a/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
@@ -899,7 +899,7 @@ void vBlankHandler()
 					glSprite(96, 92, GL_FLIP_NONE, &tex().startbrdImage()[startBorderZoomAnimSeq[startBorderZoomAnimNum] & 63]);
 					glSprite(96+32, 92, GL_FLIP_H, &tex().startbrdImage()[startBorderZoomAnimSeq[startBorderZoomAnimNum] & 63]);
 					if (bnrWirelessIcon[cursorPosition[secondaryDevice]] > 0) glSprite(96, 92, GL_FLIP_NONE, &tex().wirelessIcons()[(bnrWirelessIcon[cursorPosition[secondaryDevice]]-1) & 31]);
-				} else {
+				} else if (!isScrolling) {
 					if (showbubble && theme == 0 && needToPlayStopSound && waitForNeedToPlayStopSound == 0) {
 						mmEffectEx(&snd_stop);
 						waitForNeedToPlayStopSound = 1;
@@ -913,7 +913,7 @@ void vBlankHandler()
 
 			// Refresh the background layer.
 			if (showbubble) drawBubble(tex().bubbleImage());
-			if (showSTARTborder && theme == 0) glSprite(96, 144, GL_FLIP_NONE, &tex().startImage()[setLanguage]);
+			if (showSTARTborder && theme == 0 && !isScrolling) glSprite(96, 144, GL_FLIP_NONE, &tex().startImage()[setLanguage]);
 
 			glColor(RGB15(31, 31-(3*blfLevel), 31-(6*blfLevel)));
 			if (dbox_Ypos != -192) {

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -836,7 +836,7 @@ int main(int argc, char **argv) {
 	fontInit();
 	iconManagerInit();
 
-	keysSetRepeat(10, 1);
+	keysSetRepeat(10, 2);
 
 	vector<string> extensionList;
 	if (showNds) {

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -836,7 +836,7 @@ int main(int argc, char **argv) {
 	fontInit();
 	iconManagerInit();
 
-	keysSetRepeat(25, 5);
+	keysSetRepeat(10, 1);
 
 	vector<string> extensionList;
 	if (showNds) {


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

* Reverted commits that implemented the start border delay
* Tweaked the `keysDownRepeat` delays to mimic the system menu behaviour
  * at the same time, `keysDownRepeat` should show that left/right buttons were pressed even if there is some lag for `scanKeys`, thus fixing the start border showing for a split second.

#### Where have you tested it?

Nintendo DSi Hardware
*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
