### PR TITLE
DSi Theme: Fix shutdown on tapping an empty box.

### DIFF
--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -1636,11 +1636,17 @@ string browseForFile(const vector<string> extensionList, const char* username)
 						scanKeys();
 						touchRead(&touch);
 						if(!(keysHeld() & KEY_TOUCH)) {
-							gameTapped = true;
-							break;
+							int index = cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40;
+							// this will only work if dirContents[scrn] is a contiguous vector.
+							if (index < dirContents[scrn].size()) {
+								gameTapped = true;
+								break;
+							}
 						}
 						else if(touch.px < startTouch.px-10 || touch.px > startTouch.px+10)
+						{
 							break;
+						}
 					}
 				}
 

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -1631,6 +1631,7 @@ string browseForFile(const vector<string> extensionList, const char* username)
 				int prevPos = cursorPosition[secondaryDevice];
 				showSTARTborder = false;
 
+				// Tap start
 				if(touch.px > 96 && touch.px < 160 && touch.py < 144 && touch.py > 88) {
 					while(1) {
 						scanKeys();
@@ -1638,7 +1639,7 @@ string browseForFile(const vector<string> extensionList, const char* username)
 						if(!(keysHeld() & KEY_TOUCH)) {
 							int index = cursorPosition[secondaryDevice]+pagenum[secondaryDevice]*40;
 							// this will only work if dirContents[scrn] is a contiguous vector.
-							if (index < dirContents[scrn].size()) {
+							if (index < (int)dirContents[scrn].size()) {
 								gameTapped = true;
 								break;
 							}


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Accessing `dirContents[scrn].at(...)` when the cursor position was at an empty spot would cause an exception due to out of bounds errors. Since DS homebrew is `noexcept`, this caused the DS to shut down immediately (or quit to an error screen on TWL_FIRM).

This just does bounds checking when a box is tapped to prevent the exception from occurring.

#### Where have you tested it?

Nintendo DSi Hardware

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
