### PR TITLE
build: Use docker for travis to workaround dkA r51 incompatibilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,21 +36,20 @@ services:
 #   - export DEVKITARM=${DEVKITPRO}/devkitARM
 
 
-# addons:
-#   apt:
-#     sources:
-#     - ubuntu-toolchain-r-test
-#     packages:
-#     - gcc-4.9
-#     - g++-4.9
-#     - libstdc++6
-#     - lftp
+addons:
+  apt:
+    # sources:
+    # - ubuntu-toolchain-r-test
+    packages:
+    - p7zip-full
+    # - gcc-4.9
+    # - g++-4.9
+    # - libstdc++6
+    # - lftp
 
 before_install:
   - docker build -t twilightmenu --label twilightmenu ./docker
   - docker ps -a
-  - sudo apt-get install -y p7zip-full
-
 
 script:
   - export COMMIT_TAG="$(git log --format=%h -1)"
@@ -58,8 +57,7 @@ script:
   # - 7z x libnds.7z
   # - sudo cp -r libnds/* /opt/devkitpro/libnds/
   # - make package
-  - chmod +x ./compile_docker.sh
-  - ./compile_docker.sh
+  - docker run --rm -t -i -v "$(pwd)\:/data" twilightmenu make package
   - cd booter/
   - chmod +x make_cia
   - ./make_cia --srl="booter.nds"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,48 +1,65 @@
 language: cpp
 
 os: linux
-sudo: false
-dist: trusty
+dist: xenial
 
-env:
-  global:
-    - DEVKITPRO=/opt/devkitpro    
-    - DEVKITARM=/opt/devkitpro/devkitARM
+services:
+  - docker
+
+# env:
+#   global:
+#     - DEVKITPRO=/opt/devkitpro    
+#     - DEVKITARM=/opt/devkitpro/devkitARM
     
-cache:
-  directories:
-    - "$HOME/.local"
-    - "$DEVKITPRO"
+# cache:
+#   directories:
+#     - "$HOME/.local"
+#     - "$DEVKITPRO"
+
+# install:
+#   - sudo dpkg -i pacman.deb
+#   - sudo dkp-pacman -Sy
+#   - sudo dkp-pacman -S devkitARM general-tools dstools ndstool libnds libfat-nds grit mmutil --noconfirm
+#   - git clone https://github.com/RocketRobz/libnds.git
+#   - cd libnds/
+#   - sudo make install
+#   - cd ..
+#   - sudo rm -r libnds/
+#   - 
+#   - git clone https://github.com/RocketRobz/libnds.git
+#   - cd libnds/
+#   - sudo make install
+#   - cd ..
+#   - sudo rm -r libnds/
+#   - 
+#   - export DEVKITPRO=/opt/devkitpro
+#   - export DEVKITARM=${DEVKITPRO}/devkitARM
+
+
+# addons:
+#   apt:
+#     sources:
+#     - ubuntu-toolchain-r-test
+#     packages:
+#     - gcc-4.9
+#     - g++-4.9
+#     - libstdc++6
+#     - lftp
 
 before_install:
-  - curl -L https://github.com/devkitPro/pacman/releases/download/devkitpro-pacman-1.0.1/devkitpro-pacman.deb -o pacman.deb
+  - docker build -t twilightmenu --label twilightmenu ./docker
+  - docker ps -a
   - sudo apt-get install -y p7zip-full
 
-install:
-  - sudo dpkg -i pacman.deb
-  - sudo dkp-pacman -Sy
-  - sudo dkp-pacman -S devkitARM general-tools dstools ndstool libnds libfat-nds grit mmutil --noconfirm
-  - git clone https://github.com/RocketRobz/libnds.git
-  - cd libnds/
-  - sudo make install
-  - cd ..
-  - sudo rm -r libnds/
-  - 
-  - git clone https://github.com/RocketRobz/libnds.git
-  - cd libnds/
-  - sudo make install
-  - cd ..
-  - sudo rm -r libnds/
-  - 
-  - export DEVKITPRO=/opt/devkitpro
-  - export DEVKITARM=${DEVKITPRO}/devkitARM
 
 script:
   - export COMMIT_TAG="$(git log --format=%h -1)"
   - export COMMIT_MESSAGE="$(git log --pretty=format:"%an - %s" -1)"
-  - 7z x libnds.7z
-  - sudo cp -r libnds/* /opt/devkitpro/libnds/
-  - make package
+  # - 7z x libnds.7z
+  # - sudo cp -r libnds/* /opt/devkitpro/libnds/
+  # - make package
+  - chmod +x ./compile_docker.sh
+  - ./compile_docker.sh
   - cd booter/
   - chmod +x make_cia
   - ./make_cia --srl="booter.nds"
@@ -56,16 +73,6 @@ script:
   - mv 7zfile/ TWiLightMenu/
   - 7z a TWiLightMenu.7z TWiLightMenu/
   
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - gcc-4.9
-    - g++-4.9
-    - libstdc++6
-    - lftp
-
 after_success:
   - curl -o send.sh https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
   - chmod +x send.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
   bundler: true
   directories:
     - $HOME/docker
-    
+
 # install:
 #   - sudo dpkg -i pacman.deb
 #   - sudo dkp-pacman -Sy
@@ -70,7 +70,7 @@ script:
   # - 7z x libnds.7z
   # - sudo cp -r libnds/* /opt/devkitpro/libnds/
   # - make package
-  - docker run --rm -t -i -v "$(pwd)\:/data" twilightmenu make package
+  - docker run --rm -t -i -v "$TRAVIS_BUILD_DIR\:/data" twilightmenu make package
   - cd booter/
   - chmod +x make_cia
   - ./make_cia --srl="booter.nds"

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ script:
   # - 7z x libnds.7z
   # - sudo cp -r libnds/* /opt/devkitpro/libnds/
   # - make package
-  - docker run --rm -t -i -v "$TRAVIS_BUILD_DIR\:/data" twilightmenu make package
+  - docker run --rm -t -i -v "$TRAVIS_BUILD_DIR:/data" twilightmenu make package
   - cd booter/
   - chmod +x make_cia
   - ./make_cia --srl="booter.nds"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ services:
 #     - "$HOME/.local"
 #     - "$DEVKITPRO"
 
+cache:
+  bundler: true
+  directories:
+    - $HOME/docker
+    
 # install:
 #   - sudo dpkg -i pacman.deb
 #   - sudo dkp-pacman -Sy
@@ -47,7 +52,15 @@ addons:
     # - libstdc++6
     # - lftp
 
+before_cache:
+  # Save tagged docker images
+  - >
+    mkdir -p $HOME/docker && docker images -a --filter='dangling=false' --format '{{.Repository}}:{{.Tag}} {{.ID}}'
+    | xargs -n 2 -t sh -c 'test -e $HOME/docker/$1.tar.gz || docker save $0 | gzip -2 > $HOME/docker/$1.tar.gz'
+
 before_install:
+  # load cached docker images
+  - if [[ -d $HOME/docker ]]; then ls $HOME/docker/*.tar.gz | xargs -I {file} sh -c "zcat {file} | docker load"; fi
   - docker build -t twilightmenu --label twilightmenu ./docker
   - docker ps -a
 

--- a/compile_docker.sh
+++ b/compile_docker.sh
@@ -13,4 +13,4 @@ if [ $? -ne 0 ]; then
     docker build -t twilightmenu --label twilightmenu ./docker
 fi
 
-docker run --rm -t -i -v "$(pwd)\:/data" twilightmenu make $@
+docker run --rm -t -i -v "$(pwd):/data" twilightmenu make $@


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Seems like dkA r51 breaks the Travis build. As a workaround, we can use Docker in Travis and build with dkA r50 + patched libnds.

#### Where have you tested it?

Let's see if this builds properly on Travis before merging...

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
