### PR TITLE
Fix cheat menu opening/closing rapidly

### DIFF
--- a/romsel_dsimenutheme/arm9/source/cheat.cpp
+++ b/romsel_dsimenutheme/arm9/source/cheat.cpp
@@ -381,7 +381,7 @@ void CheatCodelist::selectCheats(std::string filename)
     if(pressed & KEY_B) {
       break;
     }
-    if(pressed & KEY_X) {
+    if(keysDown() & KEY_X) {
       clearText();
       printLargeCentered(false, 30, "Cheats");
       printSmallCentered(false, 100, "Saving...");

--- a/romsel_dsimenutheme/arm9/source/cheat.cpp
+++ b/romsel_dsimenutheme/arm9/source/cheat.cpp
@@ -313,7 +313,7 @@ void CheatCodelist::selectCheats(std::string filename)
 
 	do {
 		scanKeys();
-		pressed = keysDownRepeat();
+		pressed = keysDown();
 		loadVolumeImage();
 		loadBatteryImage();
 		loadTime();
@@ -381,7 +381,7 @@ void CheatCodelist::selectCheats(std::string filename)
     if(pressed & KEY_B) {
       break;
     }
-    if(keysDown() & KEY_X) {
+    if(pressed & KEY_X) {
       clearText();
       printLargeCentered(false, 30, "Cheats");
       printSmallCentered(false, 100, "Saving...");

--- a/romsel_r4theme/arm9/source/cheat.cpp
+++ b/romsel_r4theme/arm9/source/cheat.cpp
@@ -310,7 +310,7 @@ void CheatCodelist::selectCheats(std::string filename)
 
 	do {
 		scanKeys();
-		pressed = keysDownRepeat();
+		pressed = keysDown();
 		swiWaitForVBlank();
 	} while (!pressed);
     if(pressed & KEY_UP) {
@@ -373,7 +373,7 @@ void CheatCodelist::selectCheats(std::string filename)
     if(pressed & KEY_B) {
       break;
     }
-    if(keysDown() & KEY_X) {
+    if(pressed & KEY_X) {
       clearText();
       titleUpdate(isDirectory, filename.c_str());
       printLargeCentered(false, 84, "Cheats");

--- a/romsel_r4theme/arm9/source/cheat.cpp
+++ b/romsel_r4theme/arm9/source/cheat.cpp
@@ -373,7 +373,7 @@ void CheatCodelist::selectCheats(std::string filename)
     if(pressed & KEY_B) {
       break;
     }
-    if(pressed & KEY_X) {
+    if(keysDown() & KEY_X) {
       clearText();
       titleUpdate(isDirectory, filename.c_str());
       printLargeCentered(false, 84, "Cheats");

--- a/romsel_r4theme/arm9/source/perGameSettings.cpp
+++ b/romsel_r4theme/arm9/source/perGameSettings.cpp
@@ -400,7 +400,7 @@ void perGameSettings (std::string filename) {
 		}
 		do {
 			scanKeys();
-			pressed = keysDownRepeat();
+			pressed = keysDown();
 			swiWaitForVBlank();
 		} while (!pressed);
 


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Cheat menu no longer closes after you open it if you hold/press X too long on both the DSi/3DS and R4 themes.

#### Where have you tested it?

Old 2DS

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
