### PR TITLE
3DS & DSi themes: Truncate long filenames

### DIFF
--- a/romsel_dsimenutheme/arm9/source/perGameSettings.cpp
+++ b/romsel_dsimenutheme/arm9/source/perGameSettings.cpp
@@ -251,6 +251,10 @@ void perGameSettings (std::string filename) {
 	while (1) {
 		clearText();
 		titleUpdate(isDirectory[cursorPosition[secondaryDevice]], filename.c_str(), cursorPosition[secondaryDevice]);
+		if (strlen(filename.c_str()) > 38) {
+			filename.resize(35, ' ');
+			filename.append("...");
+		}
 		printSmall(false, 16, 66, filename.c_str());
 		if (showSDKVersion) printSmall(false, 16, 80, SDKnumbertext);
 		printSmall(false, 176, 80, gameTIDText);

--- a/romsel_dsimenutheme/arm9/source/perGameSettings.cpp
+++ b/romsel_dsimenutheme/arm9/source/perGameSettings.cpp
@@ -251,7 +251,9 @@ void perGameSettings (std::string filename) {
 	while (1) {
 		clearText();
 		titleUpdate(isDirectory[cursorPosition[secondaryDevice]], filename.c_str(), cursorPosition[secondaryDevice]);
+		// About 38 characters fit in the box.
 		if (strlen(filename.c_str()) > 38) {
+			// Truncate to 35, 35 + 3 = 38 (because we append "...").
 			filename.resize(35, ' ');
 			size_t first = filename.find_first_not_of(' ');
 			size_t last = filename.find_last_not_of(' ');

--- a/romsel_dsimenutheme/arm9/source/perGameSettings.cpp
+++ b/romsel_dsimenutheme/arm9/source/perGameSettings.cpp
@@ -253,6 +253,9 @@ void perGameSettings (std::string filename) {
 		titleUpdate(isDirectory[cursorPosition[secondaryDevice]], filename.c_str(), cursorPosition[secondaryDevice]);
 		if (strlen(filename.c_str()) > 38) {
 			filename.resize(35, ' ');
+			size_t first = filename.find_first_not_of(' ');
+			size_t last = filename.find_last_not_of(' ');
+			filename = filename.substr(first, (last - first + 1));
 			filename.append("...");
 		}
 		printSmall(false, 16, 66, filename.c_str());


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

When viewing per game settings in the DSi or 3DS themes, long filenames are truncated to prevent them from being drawn outside of the box. Example: `Patched Mario and Luigi Bowser's In...`.

#### Where have you tested it?

Old 2DS

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
