### PR TITLE
DSiMenu/akMenu Remove dependency on C++17

### DIFF
--- a/romsel_aktheme/Makefile
+++ b/romsel_aktheme/Makefile
@@ -42,7 +42,7 @@ CFLAGS	:=	-g -Wall -O2 \
 		$(ARCH)
 
 CFLAGS	+=	$(INCLUDE) -DARM9
-CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=c++1z
+CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=c++14
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=ds_arm9.specs -g -Wl,--gc-sections $(ARCH) -Wl,-Map,$(notdir $*.map)

--- a/romsel_aktheme/arm9/Makefile
+++ b/romsel_aktheme/arm9/Makefile
@@ -36,7 +36,7 @@ CFLAGS	:=	-g -Wall -O2\
 		$(ARCH)
 
 CFLAGS	+=	$(INCLUDE) -DARM9
-CXXFLAGS	:= $(CFLAGS) -fno-exceptions -std=gnu++1z
+CXXFLAGS	:= $(CFLAGS) -fno-exceptions -std=gnu++14
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=ds_arm9.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)

--- a/romsel_aktheme/arm9/source/common/singleton.h
+++ b/romsel_aktheme/arm9/source/common/singleton.h
@@ -1,6 +1,6 @@
 /*
     common/singleton.h
-    Copyright (c) 2018 RonnChyran
+    Copyright (c) 2018 chyyran
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal
@@ -56,7 +56,10 @@ class singleton
     }
 
   private:
-    static inline T *_instance = NULL;
+    static T *_instance;
 };
+
+template<typename T,  typename...Args>
+T * singleton<T, Args...>::_instance = NULL;
 
 #endif //_SINGLETON_H_

--- a/romsel_dsimenutheme/Makefile
+++ b/romsel_dsimenutheme/Makefile
@@ -43,7 +43,7 @@ CFLAGS	:=	-g -Wall -O2 \
 		$(ARCH)
 
 CFLAGS	+=	$(INCLUDE) -DARM9
-CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++1z
+CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++14
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=ds_arm9.specs -g -Wl,--gc-sections $(ARCH) -Wl,-Map,$(notdir $*.map)

--- a/romsel_dsimenutheme/Makefile
+++ b/romsel_dsimenutheme/Makefile
@@ -43,7 +43,7 @@ CFLAGS	:=	-g -Wall -O2 \
 		$(ARCH)
 
 CFLAGS	+=	$(INCLUDE) -DARM9
-CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=c++11
+CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++1z
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=ds_arm9.specs -g -Wl,--gc-sections $(ARCH) -Wl,-Map,$(notdir $*.map)

--- a/romsel_dsimenutheme/arm9/Makefile
+++ b/romsel_dsimenutheme/arm9/Makefile
@@ -36,7 +36,7 @@ CFLAGS	:=	-g -Wall -O2\
 		$(ARCH)
 
 CFLAGS	+=	$(INCLUDE) -DARM9
-CXXFLAGS	:= $(CFLAGS) -fno-exceptions -std=gnu++17
+CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++1z
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=ds_arm9.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)

--- a/romsel_dsimenutheme/arm9/Makefile
+++ b/romsel_dsimenutheme/arm9/Makefile
@@ -36,7 +36,7 @@ CFLAGS	:=	-g -Wall -O2\
 		$(ARCH)
 
 CFLAGS	+=	$(INCLUDE) -DARM9
-CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++1z
+CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++14
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=ds_arm9.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)

--- a/romsel_dsimenutheme/arm9/source/common/singleton.h
+++ b/romsel_dsimenutheme/arm9/source/common/singleton.h
@@ -56,7 +56,10 @@ class singleton
     }
 
   private:
-    static inline T *_instance = NULL;
+    static T *_instance;
 };
+
+template<typename T,  typename...Args>
+T * singleton<T, Args...>::_instance = NULL;
 
 #endif //_SINGLETON_H_

--- a/romsel_dsimenutheme/arm9/source/common/singleton.h
+++ b/romsel_dsimenutheme/arm9/source/common/singleton.h
@@ -1,6 +1,6 @@
 /*
     common/singleton.h
-    Copyright (c) 2018 RonnChyran
+    Copyright (c) 2018 chyyran
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -1516,7 +1516,7 @@ string browseForFile(const vector<string> extensionList, const char *username) {
 					gameOrder.insert(gameOrder.begin() + CURPOS + (PAGENUM * 40), gameBeingMoved);
 
 					for (int i = 0; i < (int)gameOrder.size(); i++) {
-						char str[9];
+						char str[12];
 						sprintf(str, "%d", i);
 						gameOrderIni.SetString(getcwd(path, PATH_MAX), str, gameOrder[i]);
 					}

--- a/romsel_dsimenutheme/arm9/source/iconTitle.cpp
+++ b/romsel_dsimenutheme/arm9/source/iconTitle.cpp
@@ -132,7 +132,11 @@ void deferLoadIcon(u8 *tilesSrc, u16 *palSrc, int num, bool twl) {
  */
 void execDeferredIconUpdates() {
 	for (auto arg : queuedIconUpdateCache) {
-		auto &[tilesSrc, palSrc, num, twl] = arg;
+		u8 *tilesSrc;
+		u16 *palSrc;
+		int num;
+		bool twl;
+		std::tie(tilesSrc, palSrc, num, twl) = arg;
 		convertIconTilesToRaw(tilesSrc, tilesModified, twl);
 		glLoadIcon(num, (u16 *)palSrc, (u8 *)tilesModified, twl ? TWL_TEX_HEIGHT : 32);
 	}


### PR DESCRIPTION
#### What's changed?
C++17 features have been replaced with C++14 workarounds for `dsimenu` and `akmenu`. `settings` relies heavily on C++17 features so it has not been touched.

Hopefully this will increase compatibility with older toolchains (at little to no cost).
*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
