### PR TITLE
Don't use negative fseek.

### DIFF
--- a/romsel_dsimenutheme/arm9/source/common/singleton.h
+++ b/romsel_dsimenutheme/arm9/source/common/singleton.h
@@ -26,6 +26,7 @@
 #define _SINGLETON_H_
 #include <cstdlib>
 #include <utility>
+#include <new>          // std::nothrow
 
 template <typename T, typename... Args>
 class singleton
@@ -43,7 +44,7 @@ class singleton
     static inline void make(Args... args)
     {
         if (!_instance)
-            _instance = new T(std::forward<Args>(args)...);
+            _instance = new (std::nothrow) T(std::forward<Args>(args)...);
     }
 
     static inline void reset()

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -235,7 +235,7 @@ struct DirEntry {
 };
 
 TextEntry *pathText = nullptr;
-char *path = new char[PATH_MAX];
+char path[PATH_MAX] = {0};
 
 #ifdef EMULATE_FILES
 #define chdir(a) chdirFake(a)

--- a/romsel_dsimenutheme/arm9/source/graphics/Texture.h
+++ b/romsel_dsimenutheme/arm9/source/graphics/Texture.h
@@ -35,8 +35,8 @@ class Texture
     typedef void (*BitmapEffect)(u16* texture, u32 texLength);
 
     private:
-        unique_ptr<unsigned short []> _palette;
-        unique_ptr<unsigned short []> _texture;
+        unique_ptr<u16[]> _palette;
+        unique_ptr<u16[]> _texture;
         u8 _paletteLength;
         u32 _texLength; // in words
         u32 _texCmpLength;

--- a/romsel_dsimenutheme/arm9/source/graphics/iconHandler.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/iconHandler.cpp
@@ -34,8 +34,8 @@ glImage _snesIcon[1];
 // glImage _msxIcon[1];
 // glImage _colIcon[1];
 
-u8 *clearTiles;
-u16 *blackPalette;
+static u8 clearTiles[(32 * 256) / 2] = {0};
+static u16 blackPalette[16 * 8] = {0};
 
 /**
  * Gets the current icon stored at the specified index.
@@ -295,8 +295,6 @@ void glClearIcon(int num) { glLoadIcon(num, blackPalette, clearTiles, 256, true)
  * icons. Must be called before the icon manager is used.
  */
 void iconManagerInit() {
-	clearTiles = new u8[(32 * 256) / 2]();
-	blackPalette = new u16[16 * 8]();
 
 	// Allocate texture memory for 6 textures.
 	glGenTextures(NDS_ICON_BANK_COUNT, _iconTexID);

--- a/romsel_dsimenutheme/arm9/source/iconTitle.cpp
+++ b/romsel_dsimenutheme/arm9/source/iconTitle.cpp
@@ -61,7 +61,7 @@ static bool infoFound[41] = {false};
 static u16 cachedTitle[41][TITLE_CACHE_SIZE];
 static char titleToDisplay[3][384];
 
-u8 *tilesModified = new u8[(32 * 256) / 2];
+u8 tilesModified[(32 * 256) / 2] = {0};
 
 std::vector<std::tuple<u8 *, u16 *, int, bool>> queuedIconUpdateCache;
 

--- a/romsel_dsimenutheme/resources/dsimenu_theme_examples/theming.md
+++ b/romsel_dsimenutheme/resources/dsimenu_theme_examples/theming.md
@@ -1,4 +1,4 @@
-[# Creating Custom Themes (instructions for end users)
+# Creating Custom Themes (instructions for end users)
 
 The easiest way of customizing a theme is by editing the BMP textures in a theme's *ui*, *battery*, or *volume* folder. These BMP textures must be in RGB565 format, and use `#FF00FF` as a transparent key color. BMP textures are allowed to vary in size, but may require tweaking of the theme configuration to render correctly (see below).
 


### PR DESCRIPTION
#### What's changed?

Loading compressed textures used to use negative fseek. This did not work in some versions of libsysbase, causing corrupt data to be read into the texture buffers, and thus white screens.

This PR also gets rid of some unnecessary heap allocations and uses the `nothrow` version of new for singletons.

#### Where have you tested it?

NO$GBA, Nintendo DSi, Nintendo DS Lite (thanks @FlameKat53)

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
