### PR TITLE
3DS Theme: Fix the flicker when going between games with boxarts

### DIFF
--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -508,9 +508,11 @@ void updateBoxArt(vector<vector<DirEntry>> dirContents, SwitchState scrn) {
 					clearBoxArt(); // Clear box art, if it's a directory
 				}
 			} else {
-				rocketVideo_playVideo = false;
-				if (ms().theme == 1)
-					clearBoxArt();		      // Clear top screen cubes or box art
+				if (ms().theme == 1 && rocketVideo_playVideo) {
+					clearBoxArt();		
+					rocketVideo_playVideo = false;
+				}
+			      // Clear top screen cubes or box art
 				tex().drawBoxArt(boxArtPath[CURPOS]); // Load box art
 			}
 			boxArtLoaded = true;


### PR DESCRIPTION
* Only clear the box art if the video was playing before

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
