### PR TITLE
azure-pipelines: Make make_cia deterministic with the commit ID and restore the ROM icon banner

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,13 +37,13 @@ jobs:
     - script: |
         cd booter/
         chmod +x make_cia
-        ./make_cia --srl=booter.nds
+        ./make_cia --srl="booter.nds" --id_0=$(git rev-parse --short=7 HEAD) --tikID=$(git rev-parse --short=16 HEAD)
         mkdir -p "../7zfile/3DS - CFW users/"
         cp "booter.cia" "../7zfile/3DS - CFW users/TWiLight Menu.cia"
 
         cd ../rungame/
         chmod +x make_cia
-        ./make_cia --srl=rungame.nds
+        ./make_cia --srl="rungame.nds" --id_0=$(git rev-parse --short=7 HEAD) --tikID=$(git rev-parse --short=16 HEAD)
         cp "rungame.cia" "../7zfile/3DS - CFW users/TWiLight Menu - Game booter.cia"
       displayName: 'Make booter and TWiLightMenu CIAs'
       
@@ -82,12 +82,12 @@ jobs:
       - script: |
           cd booter/
           chmod +x make_cia
-          ./make_cia --srl=booter.nds
+          ./make_cia --srl="booter.nds" --id_0=$(git rev-parse --short=7 HEAD) --tikID=$(git rev-parse --short=16 HEAD)
           mkdir -p "../7zfile/3DS - CFW users/"
           cp "booter.cia" "../7zfile/3DS - CFW users/TWiLight Menu.cia"
           cd ../rungame/
           chmod +x make_cia
-          ./make_cia --srl=rungame.nds
+          ./make_cia --srl="rungame.nds" --id_0=$(git rev-parse --short=7 HEAD) --tikID=$(git rev-parse --short=16 HEAD)
           cp "rungame.cia" "../7zfile/3DS - CFW users/TWiLight Menu - Game booter.cia"
         displayName: 'Make booter and TWiLightMenu CIAs'
         

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,6 @@ jobs:
     - script: |
         export DEVKITPRO="/opt/devkitpro"
         export DEVKITARM="/opt/devkitpro/devkitARM"
-        export TICKET_ID=$(git rev-parse --short master)
 
         sudo cp libmm7.a /opt/devkitpro/libnds/lib/libmm7.a
 
@@ -37,13 +36,13 @@ jobs:
 
         cd booter/
         chmod +x make_cia
-        ./make_cia --srl="booter.nds" --id_0 $TICKET_ID --tikID $TICKET_ID
+        ./make_cia --srl="booter.nds" --id_0 $(Build.SourceVersion) --tikID $(Build.SourceVersion)
         mkdir -p "../7zfile/3DS - CFW users/"
         cp "booter.cia" "../7zfile/3DS - CFW users/TWiLight Menu.cia"
 
         cd ../rungame/
         chmod +x make_cia
-        ./make_cia --srl="rungame.nds" --id_0 $TICKET_ID --tikID $TICKET_ID
+        ./make_cia --srl="rungame.nds" --id_0 $(Build.SourceVersion) --tikID $(Build.SourceVersion)
         cp "rungame.cia" "../7zfile/3DS - CFW users/TWiLight Menu - Game booter.cia"
       displayName: 'Build TWiLight Menu++ with latest devkitARM'
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,13 +36,13 @@ jobs:
 
         cd booter/
         chmod +x make_cia
-        ./make_cia --srl="booter.nds" --id_0= $(Build.SourceVersion) --tikID=$(Build.SourceVersion)
+        ./make_cia --srl="booter.nds" --id_0=$(git rev-parse --short=7 HEAD) --tikID=$(git rev-parse --short=16 HEAD)
         mkdir -p "../7zfile/3DS - CFW users/"
         cp "booter.cia" "../7zfile/3DS - CFW users/TWiLight Menu.cia"
 
         cd ../rungame/
         chmod +x make_cia
-        ./make_cia --srl="rungame.nds" --id_0=$(Build.SourceVersion) --tikID=$(Build.SourceVersion)
+        ./make_cia --srl="rungame.nds" --id_0=$(git rev-parse --short=7 HEAD) --tikID=$(git rev-parse --short=16 HEAD)
         cp "rungame.cia" "../7zfile/3DS - CFW users/TWiLight Menu - Game booter.cia"
       displayName: 'Build TWiLight Menu++ with latest devkitARM'
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,9 +31,10 @@ jobs:
         export DEVKITARM="/opt/devkitpro/devkitARM"
 
         sudo cp libmm7.a /opt/devkitpro/libnds/lib/libmm7.a
-
         make package
-
+      displayName: 'Build TWiLight Menu++ with latest devkitARM'
+  
+    - script: |
         cd booter/
         chmod +x make_cia
         ./make_cia --srl="booter.nds" --id_0=$(git rev-parse --short=7 HEAD) --tikID=$(git rev-parse --short=16 HEAD)
@@ -44,12 +45,14 @@ jobs:
         chmod +x make_cia
         ./make_cia --srl="rungame.nds" --id_0=$(git rev-parse --short=7 HEAD) --tikID=$(git rev-parse --short=16 HEAD)
         cp "rungame.cia" "../7zfile/3DS - CFW users/TWiLight Menu - Game booter.cia"
-      displayName: 'Build TWiLight Menu++ with latest devkitARM'
+      displayName: 'Make booter and TWiLightMenu CIAs'
+      
     - script: |
         mv 7zfile/ TWiLightMenu/
         7z a TWiLightMenu.7z TWiLightMenu/
         cp TWiLightMenu.7z $(Build.ArtifactStagingDirectory)/TWiLightMenu.7z
       displayName: 'Pack 7z Package'
+      
     - task: PublishBuildArtifacts@1
       displayName: "Publish build to Azure"
       inputs:
@@ -75,6 +78,19 @@ jobs:
       - script: |
           docker run --rm -i -v "$(Build.SourcesDirectory):/data" twilightmenu make package
         displayName: "Build TWiLightMenu++ with Docker using forked libnds and devkitARM r50"
+        
+      - script: |
+          cd booter/
+          chmod +x make_cia
+          ./make_cia --srl="booter.nds" --id_0=$(git rev-parse --short=7 HEAD) --tikID=$(git rev-parse --short=16 HEAD)
+          mkdir -p "../7zfile/3DS - CFW users/"
+          cp "booter.cia" "../7zfile/3DS - CFW users/TWiLight Menu.cia"
+          cd ../rungame/
+          chmod +x make_cia
+          ./make_cia --srl="rungame.nds" --id_0=$(git rev-parse --short=7 HEAD) --tikID=$(git rev-parse --short=16 HEAD)
+          cp "rungame.cia" "../7zfile/3DS - CFW users/TWiLight Menu - Game booter.cia"
+        displayName: 'Make booter and TWiLightMenu CIAs'
+        
       - script: |
           mv 7zfile/ TWiLightMenu/
           7z a TWiLightMenu.7z TWiLightMenu/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,13 +37,13 @@ jobs:
     - script: |
         cd booter/
         chmod +x make_cia
-        ./make_cia --srl="booter.nds" --id_0=$(git rev-parse --short=7 HEAD) --tikID=$(git rev-parse --short=16 HEAD)
+        ./make_cia --srl=booter.nds
         mkdir -p "../7zfile/3DS - CFW users/"
         cp "booter.cia" "../7zfile/3DS - CFW users/TWiLight Menu.cia"
 
         cd ../rungame/
         chmod +x make_cia
-        ./make_cia --srl="rungame.nds" --id_0=$(git rev-parse --short=7 HEAD) --tikID=$(git rev-parse --short=16 HEAD)
+        ./make_cia --srl=rungame.nds
         cp "rungame.cia" "../7zfile/3DS - CFW users/TWiLight Menu - Game booter.cia"
       displayName: 'Make booter and TWiLightMenu CIAs'
       
@@ -82,12 +82,12 @@ jobs:
       - script: |
           cd booter/
           chmod +x make_cia
-          ./make_cia --srl="booter.nds" --id_0=$(git rev-parse --short=7 HEAD) --tikID=$(git rev-parse --short=16 HEAD)
+          ./make_cia --srl=booter.nds
           mkdir -p "../7zfile/3DS - CFW users/"
           cp "booter.cia" "../7zfile/3DS - CFW users/TWiLight Menu.cia"
           cd ../rungame/
           chmod +x make_cia
-          ./make_cia --srl="rungame.nds" --id_0=$(git rev-parse --short=7 HEAD) --tikID=$(git rev-parse --short=16 HEAD)
+          ./make_cia --srl=rungame.nds
           cp "rungame.cia" "../7zfile/3DS - CFW users/TWiLight Menu - Game booter.cia"
         displayName: 'Make booter and TWiLightMenu CIAs'
         

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,6 @@ variables:
   CURRENT_DATE: $[format('{0:yyyyMMdd\-HHmmss}', pipeline.startTime)]
   REPOSITORY_NAME: $(Build.Repository.Name)
   COMMIT_TAG: $(git log --format=%h -1)
-  TICKET_ID: $(git rev-parse --short master)
 
 jobs:
   - job: latest_build
@@ -30,6 +29,7 @@ jobs:
     - script: |
         export DEVKITPRO="/opt/devkitpro"
         export DEVKITARM="/opt/devkitpro/devkitARM"
+        export TICKET_ID=$(git rev-parse --short master)
 
         sudo cp libmm7.a /opt/devkitpro/libnds/lib/libmm7.a
 
@@ -37,13 +37,13 @@ jobs:
 
         cd booter/
         chmod +x make_cia
-        ./make_cia --srl="booter.nds"
+        ./make_cia --srl="booter.nds" --id_0 $TICKET_ID --tikID $TICKET_ID
         mkdir -p "../7zfile/3DS - CFW users/"
         cp "booter.cia" "../7zfile/3DS - CFW users/TWiLight Menu.cia"
 
         cd ../rungame/
         chmod +x make_cia
-        ./make_cia --srl="rungame.nds" --id_0 $(TICKET_ID) -- tikID $(TICKET_ID)
+        ./make_cia --srl="rungame.nds" --id_0 $TICKET_ID --tikID $TICKET_ID
         cp "rungame.cia" "../7zfile/3DS - CFW users/TWiLight Menu - Game booter.cia"
       displayName: 'Build TWiLight Menu++ with latest devkitARM'
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,7 @@ variables:
   CURRENT_DATE: $[format('{0:yyyyMMdd\-HHmmss}', pipeline.startTime)]
   REPOSITORY_NAME: $(Build.Repository.Name)
   COMMIT_TAG: $(git log --format=%h -1)
+  TICKET_ID: $(git rev-parse --short master)
 
 jobs:
   - job: latest_build
@@ -42,7 +43,7 @@ jobs:
 
         cd ../rungame/
         chmod +x make_cia
-        ./make_cia --srl="rungame.nds"
+        ./make_cia --srl="rungame.nds" --id_0 $(TICKET_ID) -- tikID $(TICKET_ID)
         cp "rungame.cia" "../7zfile/3DS - CFW users/TWiLight Menu - Game booter.cia"
       displayName: 'Build TWiLight Menu++ with latest devkitARM'
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,13 +36,13 @@ jobs:
 
         cd booter/
         chmod +x make_cia
-        ./make_cia --srl="booter.nds" --id_0 $(Build.SourceVersion) --tikID $(Build.SourceVersion)
+        ./make_cia --srl="booter.nds" --id_0= $(Build.SourceVersion) --tikID=$(Build.SourceVersion)
         mkdir -p "../7zfile/3DS - CFW users/"
         cp "booter.cia" "../7zfile/3DS - CFW users/TWiLight Menu.cia"
 
         cd ../rungame/
         chmod +x make_cia
-        ./make_cia --srl="rungame.nds" --id_0 $(Build.SourceVersion) --tikID $(Build.SourceVersion)
+        ./make_cia --srl="rungame.nds" --id_0=$(Build.SourceVersion) --tikID=$(Build.SourceVersion)
         cp "rungame.cia" "../7zfile/3DS - CFW users/TWiLight Menu - Game booter.cia"
       displayName: 'Build TWiLight Menu++ with latest devkitARM'
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ jobs:
     - script: |
         export DEVKITPRO="/opt/devkitpro"
         export DEVKITARM="/opt/devkitpro/devkitARM"
-
+        export TWLNOPATCHSRLHEADER=1
         sudo cp libmm7.a /opt/devkitpro/libnds/lib/libmm7.a
         make package
       displayName: 'Build TWiLight Menu++ with latest devkitARM'

--- a/booter/Makefile
+++ b/booter/Makefile
@@ -131,8 +131,7 @@ dist:	all
 	
 $(TARGET).nds:	$(TARGET).arm7 $(TARGET).arm9
 	ndstool	-c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \
-			-g SRLA 01 "TWLMENUPP" -z 80040000 -u 00030004
-			# -b icon.bmp "TWiLight Menu++;RocketRobz"
+			-g SRLA 01 "TWLMENUPP" -z 80040000 -u 00030004 -b icon.bmp "TWiLight Menu++;RocketRobz"
 			
 ifneq ($(strip $(TWLNOPATCHSRLHEADER)), 1)
 		python2 patch_ndsheader_dsiware.py $(TARGET).nds

--- a/booter/Makefile
+++ b/booter/Makefile
@@ -133,8 +133,10 @@ $(TARGET).nds:	$(TARGET).arm7 $(TARGET).arm9
 	ndstool	-c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \
 			-g SRLA 01 "TWLMENUPP" -z 80040000 -u 00030004
 			# -b icon.bmp "TWiLight Menu++;RocketRobz"
-
-	python2 patch_ndsheader_dsiware.py $(CURDIR)/$(TARGET).nds
+			
+ifneq ($(strip $(TWLNOPATCHSRLHEADER)), 1)
+		python2 patch_ndsheader_dsiware.py $(TARGET).nds
+endif
 
 $(TARGET).arm7: arm7/$(TARGET).elf
 	cp arm7/$(TARGET).elf $(TARGET).arm7.elf

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM devkitpro/devkitarm:20190212
 ADD libnds.tar /opt/devkitpro
+ENV TWLNOPATCHSRLHEADER=1
 RUN \
   apt-get update && \
   apt-get install -y python && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,11 @@
 FROM devkitpro/devkitarm:20190212
 ADD libnds.tar /opt/devkitpro
 ENV TWLNOPATCHSRLHEADER=1
-RUN \
-  apt-get update && \
-  apt-get install -y python && \
-  rm -rf /var/lib/apt/lists/* 
-  # git clone https://github.com/RocketRobz/libnds /temp/libnds && \
-  # cd /temp/libnds && \
-  # make install
+# RUN \
+#   apt-get update && \
+#   apt-get install -y python && \
+#   rm -rf /var/lib/apt/lists/* 
+#   # git clone https://github.com/RocketRobz/libnds /temp/libnds && \
+#   # cd /temp/libnds && \
+#   # make install
 WORKDIR /data

--- a/rungame/Makefile
+++ b/rungame/Makefile
@@ -133,7 +133,9 @@ $(TARGET).nds:	$(TARGET).arm7 $(TARGET).arm9
 	ndstool	-u 00030015 -g SLRN -c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \
 			-g SLRN 01 "TWLMENUPP-LR" -b icon.bmp "TWiLight Menu++;Last-run ROM;RocketRobz"
 
-	python2 patch_ndsheader_dsiware.py $(TARGET).nds
+ifneq ($(strip $(TWLNOPATCHSRLHEADER)), 1)
+		python2 patch_ndsheader_dsiware.py $(TARGET).nds
+endif
 
 $(TARGET).arm7: arm7/$(TARGET).elf
 	cp arm7/$(TARGET).elf $(TARGET).arm7.elf


### PR DESCRIPTION
Fixes booter and LRR cias on TWLbot. Thanks to @Elaugaufein from Discord for investigating.

Confirmed working on n3DS.