### PR TITLE
 Renable manual SRL header patching for booter/rungame.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ jobs:
     - script: |
         export DEVKITPRO="/opt/devkitpro"
         export DEVKITARM="/opt/devkitpro/devkitARM"
-        export TWLNOPATCHSRLHEADER=1
+        # export TWLNOPATCHSRLHEADER=1
         sudo cp libmm7.a /opt/devkitpro/libnds/lib/libmm7.a
         make package
       displayName: 'Build TWiLight Menu++ with latest devkitARM'

--- a/booter/Makefile
+++ b/booter/Makefile
@@ -131,7 +131,7 @@ dist:	all
 	
 $(TARGET).nds:	$(TARGET).arm7 $(TARGET).arm9
 	ndstool	-c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \
-			-g SRLA 01 "TWLMENUPP" -z 80040000 -u 00030004 -b icon.bmp "TWiLight Menu++;RocketRobz"
+			-g SRLA 01 "TWLMENUPP" -z 80040000 -u 00030004 -a 00000138 -b icon.bmp "TWiLight Menu++;RocketRobz"
 			
 ifneq ($(strip $(TWLNOPATCHSRLHEADER)), 1)
 		python2 patch_ndsheader_dsiware.py $(TARGET).nds

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,11 @@
 FROM devkitpro/devkitarm:20190212
 ADD libnds.tar /opt/devkitpro
-ENV TWLNOPATCHSRLHEADER=1
-# RUN \
-#   apt-get update && \
-#   apt-get install -y python && \
-#   rm -rf /var/lib/apt/lists/* 
-#   # git clone https://github.com/RocketRobz/libnds /temp/libnds && \
-#   # cd /temp/libnds && \
-#   # make install
+# ENV TWLNOPATCHSRLHEADER=1
+RUN \
+  apt-get update && \
+  apt-get install -y python && \
+  rm -rf /var/lib/apt/lists/* 
+  # git clone https://github.com/RocketRobz/libnds /temp/libnds && \
+  # cd /temp/libnds && \
+  # make install
 WORKDIR /data

--- a/rungame/Makefile
+++ b/rungame/Makefile
@@ -131,7 +131,7 @@ dist:	all
 	
 $(TARGET).nds:	$(TARGET).arm7 $(TARGET).arm9
 	ndstool	-u 00030015 -g SLRN -c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \
-			-g SLRN 01 "TWLMENUPP-LR" -b icon.bmp "TWiLight Menu++;Last-run ROM;RocketRobz"
+			-g SLRN 01 "TWLMENUPP-LR" -a 00000138 -z 80040000 -b icon.bmp "TWiLight Menu++;Last-run ROM;RocketRobz"
 
 ifneq ($(strip $(TWLNOPATCHSRLHEADER)), 1)
 		python2 patch_ndsheader_dsiware.py $(TARGET).nds


### PR DESCRIPTION
Touch on 3DS doesn't work with the latest nightly booter CIAs. It might have something to do with the SRL header not being patched properly? 

