### PR TITLE
DSi/3DS Themes: Add file type sorting (Fixes: #406)

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,26 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "Make",
+			"type": "shell",
+			"command": "make",
+			"args": [
+				"${input:makeVariable}"
+			],
+			"group": "build",
+			"problemMatcher": [
+				"$gcc"
+			]
+		}
+	],
+	"inputs": [
+		{
+				"id": "makeVariable",
+				"description": "What do you want to make?",
+				"type": "pickString",
+				"options": ["all","clean","package","booter","booter_fc","mainmenu","manual","romsel_aktheme","romsel_dsimenutheme","romsel_r4theme","rungame","settings","slot1launch","title"],
+				"default": "all"
+		}
+	]
+}

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -403,6 +403,17 @@ bool dirEntryPredicateMostPlayed(const DirEntry &lhs, const DirEntry &rhs) {
 	}
 }
 
+bool dirEntryPredicateFileType(const DirEntry &lhs, const DirEntry &rhs) {
+	if (!lhs.isDirectory && rhs.isDirectory)	return false;
+	else if (lhs.isDirectory && !rhs.isDirectory)	return true;
+
+	if(strcasecmp(lhs.name.substr(lhs.name.find_last_of(".") + 1).c_str(), rhs.name.substr(rhs.name.find_last_of(".") + 1).c_str()) == 0) {
+		return strcasecmp(lhs.name.c_str(), rhs.name.c_str()) < 0;
+	} else {
+		return strcasecmp(lhs.name.substr(lhs.name.find_last_of(".") + 1).c_str(), rhs.name.substr(rhs.name.find_last_of(".") + 1).c_str()) < 0;
+	}
+}
+
 void getDirectoryContents(vector<DirEntry> &dirContents, const vector<string> extensionList) {
 
 	dirContents.clear();
@@ -522,7 +533,9 @@ void getDirectoryContents(vector<DirEntry> &dirContents, const vector<string> ex
 				}
 			}
 			sort(dirContents.begin(), dirContents.end(), dirEntryPredicateMostPlayed);
-		} else if(ms().sortMethod == 3) { // Custom
+		} else if(ms().sortMethod == 3) { // File type
+			sort(dirContents.begin(), dirContents.end(), dirEntryPredicateFileType);
+		} else if(ms().sortMethod == 4) { // Custom
 			CIniFile gameOrderIni(gameOrderIniPath);
 			vector<std::string> gameOrder;
 
@@ -1736,7 +1749,7 @@ string browseForFile(const vector<string> extensionList) {
 					}
 					gameOrderIni.SaveIniFile(gameOrderIniPath);
 
-					ms().sortMethod = 3;
+					ms().sortMethod = 4;
 					ms().saveSettings();
 
 					// getDirectoryContents(dirContents[scrn], extensionList);

--- a/settings/arm9/source/language.cpp
+++ b/settings/arm9/source/language.cpp
@@ -47,6 +47,7 @@ std::string STR_HIDE = "STR_HIDE";
 std::string STR_ALPHABETICAL = "STR_ALPHABETICAL";
 std::string STR_RECENT = "STR_RECENT";
 std::string STR_MOST_PLAYED = "STR_MOST_PLAYED";
+std::string STR_FILE_TYPE = "STR_FILE_TYPE";
 std::string STR_CUSTOM = "STR_CUSTOM";
 
 std::string STR_DESCRIPTION_COLORMODE = "STR_DESCRIPTION_COLORMODE";
@@ -325,6 +326,7 @@ void langInit(void)
 	STR_ALPHABETICAL = ConvertFromUTF8(languageini.GetString("LANGUAGE", "ALPHABETICAL", "Alphabetical"));
 	STR_RECENT = ConvertFromUTF8(languageini.GetString("LANGUAGE", "RECENT", "Recent"));
 	STR_MOST_PLAYED = ConvertFromUTF8(languageini.GetString("LANGUAGE", "MOST_PLAYED", "Most Played"));
+	STR_FILE_TYPE = ConvertFromUTF8(languageini.GetString("LANGUAGE", "FILE_TYPE", "File Type"));
 	STR_CUSTOM = ConvertFromUTF8(languageini.GetString("LANGUAGE", "CUSTOM", "Custom"));
 
 	STR_DESCRIPTION_COLORMODE = ConvertFromUTF8(languageini.GetString("LANGUAGE", "DESCRIPTION_COLORMODE", "Changes the color of your screens. May not work in all areas. Exit settings for the change to take effect."));
@@ -347,7 +349,7 @@ void langInit(void)
 
 	STR_DESCRIPTION_DSIMENUPPLOGO_1 = ConvertFromUTF8(languageini.GetString("LANGUAGE", "DESCRIPTION_DSIMENUPPLOGO_1", "The logo will be shown when you start TWiLight Menu++."));
 
-	STR_DESCRIPTION_SORT_METHOD = ConvertFromUTF8(languageini.GetString("LANGUAGE", "DESCRIPTION_SORT_METHOD", "Changes whether to sort alphabetically, by recently played, by most played, or custom."));
+	STR_DESCRIPTION_SORT_METHOD = ConvertFromUTF8(languageini.GetString("LANGUAGE", "DESCRIPTION_SORT_METHOD", "Changes whether to sort alphabetically, by recently played, by most played, by file type, or custom."));
 
 	STR_DESCRIPTION_DIRECTORIES_1 = ConvertFromUTF8(languageini.GetString("LANGUAGE", "DESCRIPTION_DIRECTORIES_1", "If you're in a folder where most of your games are, it is safe to hide directories/folders."));
 

--- a/settings/arm9/source/language.h
+++ b/settings/arm9/source/language.h
@@ -40,6 +40,7 @@ extern std::string STR_HIDE;
 extern std::string STR_ALPHABETICAL;
 extern std::string STR_RECENT;
 extern std::string STR_MOST_PLAYED;
+extern std::string STR_FILE_TYPE;
 extern std::string STR_CUSTOM;
 
 extern std::string STR_DESCRIPTION_COLORMODE;

--- a/settings/arm9/source/main.cpp
+++ b/settings/arm9/source/main.cpp
@@ -463,7 +463,7 @@ int main(int argc, char **argv)
 				Option::Int(&ms().dsiMusic),
 				{STR_OFF, "Regular", "DSi Shop"},
 				{0, 1, 2})
-		.option(STR_SORT_METHOD, STR_DESCRIPTION_SORT_METHOD, Option::Int(&ms().sortMethod), {STR_ALPHABETICAL, STR_RECENT, STR_MOST_PLAYED, STR_CUSTOM}, {0, 1, 2, 3})
+		.option(STR_SORT_METHOD, STR_DESCRIPTION_SORT_METHOD, Option::Int(&ms().sortMethod), {STR_ALPHABETICAL, STR_RECENT, STR_MOST_PLAYED, STR_FILE_TYPE, STR_CUSTOM}, {0, 1, 2, 3, 4})
 		.option(STR_DIRECTORIES, STR_DESCRIPTION_DIRECTORIES_1, Option::Bool(&ms().showDirectories), {STR_SHOW, STR_HIDE}, {true, false})
 		.option(STR_SHOW_HIDDEN, STR_DESCRIPTION_SHOW_HIDDEN_1, Option::Bool(&ms().showHidden), {STR_SHOW, STR_HIDE}, {true, false})
 		.option(STR_BOXART, STR_DESCRIPTION_BOXART_1, Option::Bool(&ms().showBoxArt), {STR_SHOW, STR_HIDE}, {true, false})

--- a/settings/nitrofiles/languages/english.ini
+++ b/settings/nitrofiles/languages/english.ini
@@ -27,6 +27,7 @@ HIDE = Hide
 ALPHABEICAL = Alphabetial
 RECENT = Recent
 MOST_PLAYED = Most played
+CUSTOM = File Type
 CUSTOM = Custom
 
 
@@ -40,7 +41,7 @@ DESCRIPTION_DSIMENUPPLOGO_1 = The logo will be shown when you start TWiLight Men
 DESCRIPTION_SRLOADERLOGO_1 = The logo will be shown when you start SRLoader.
 DESCRIPTION_DSISIONXLOGO_1 = The logo will be shown when you start DSiMenu++.
 
-DESCRIPTION_SORT_METHOD = Changes whether to sort alphabetically, by recently played, by most played, or custom.
+DESCRIPTION_SORT_METHOD = Changes whether to sort alphabetically, by recently played, by most played, by file type, or custom.
 
 DESCRIPTION_DIRECTORIES_1 = If you are in a folder where most of your games are, it is safe to hide directories/folders.
 


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- This adds the ability to sort games by file type
  - It sorts alphabetically by file extension, then alphabetically by file name within an extension
  - This resolves #406 

#### Where have you tested it?

DSi (J) with the latest TWiLight / Hiya / Unlaunch.

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
