### PR TITLE
Small bugfixes

### DIFF
--- a/romsel_aktheme/arm9/source/windows/mainlist.cpp
+++ b/romsel_aktheme/arm9/source/windows/mainlist.cpp
@@ -427,6 +427,10 @@ void MainList::backParentDir()
         return;
     }
 
+    if (!strncmp(_currentDir.c_str(), "^*::", 4)) {
+        return;
+    }
+
     if (!ms().showDirectories)
     {
         // Allow going back into the root, but don't allow going

--- a/romsel_aktheme/arm9/source/windows/mainwnd.cpp
+++ b/romsel_aktheme/arm9/source/windows/mainwnd.cpp
@@ -477,7 +477,6 @@ void MainWnd::bootArgv(DSRomInfo &rominfo)
     std::string fullPath = _mainList->getSelectedFullPath();
     std::string launchPath = fullPath;
     std::vector<const char *> cargv{};
-
     if (rominfo.isArgv())
     {
         ArgvFile argv(fullPath);
@@ -1001,8 +1000,6 @@ void MainWnd::onFolderChanged()
     resetInputIdle();
     std::string dirShowName = _mainList->getCurrentDir();
 
-    if (dirShowName.substr(0, 1) == SD_ROOT)
-        dirShowName.replace(0, 1, "SD:/");
 
     if (!strncmp(dirShowName.c_str(), "^*::", 2))
     {

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -1232,8 +1232,7 @@ string browseForFile(const vector<string> extensionList) {
 		getFileInfo(scrn, dirContents, true);
 		reloadIconPalettes();
 		reloadFontPalettes();
-		while (!screenFadedOut())
-			;
+		while (!screenFadedOut()) { snd().updateStream(); }
 		nowLoadingDisplaying = false;
 		whiteScreen = false;
 		fadeType = true; // Fade in from white
@@ -1555,8 +1554,8 @@ string browseForFile(const vector<string> extensionList) {
 							getDirectoryContents(dirContents[scrn], extensionList);
 							getFileInfo(scrn, dirContents, true);
 
-							while (!screenFadedOut())
-								;
+							while (!screenFadedOut()) { snd().updateStream(); }
+								
 							nowLoadingDisplaying = false;
 							whiteScreen = false;
 							fadeType = true; // Fade in from white
@@ -1584,6 +1583,7 @@ string browseForFile(const vector<string> extensionList) {
 						sprintf(str, "%d", i);
 						gameOrder.push_back(
 						    gameOrderIni.GetString(getcwd(path, PATH_MAX), str, "NULL"));
+						snd().updateStream();
 						if (gameOrder[i] == "NULL" || ms().sortMethod != 3)
 							gameOrder[i] = dirContents[scrn][i].name;
 					}
@@ -1602,6 +1602,7 @@ string browseForFile(const vector<string> extensionList) {
 						sprintf(str, "%d", i);
 						if (gameOrderIni.GetString(getcwd(path, PATH_MAX), str, "") != "") {
 							gameOrderIni.SetString(getcwd(path, PATH_MAX), str, "");
+							snd().updateStream();
 						} else {
 							break;
 						}
@@ -1626,11 +1627,14 @@ string browseForFile(const vector<string> extensionList) {
 						char str[12] = {0};
 						sprintf(str, "%d", i);
 						gameOrderIni.SetString(getcwd(path, PATH_MAX), str, gameOrder[i]);
+						snd().updateStream();
 					}
+					snd().updateStream();
 					gameOrderIni.SaveIniFile(gameOrderIniPath);
 
 					ms().sortMethod = 4;
 					ms().saveSettings();
+					snd().updateStream();
 
 					// getDirectoryContents(dirContents[scrn], extensionList);
 


### PR DESCRIPTION
#### What's changed?

* Disabled going back from the top level folder in akmenu
* Fill the stream buffer during fadeout/fadein in dsimenu to mitigate missed fills

#### Where have you tested it?
Nintendo DS Lite

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
